### PR TITLE
Clarify SDK import guidance in skill docs

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -26,5 +26,6 @@ When instrumenting an existing agent, default to this order:
 1. Run `skills/bootstrap-existing-agent-with-prefactor-cli/SKILL.md` to set up resources (`environment`, `agent`, `agent_instance`).
 2. Install required Prefactor npm package(s) via the project's package manager.
 3. Choose the matching adapter package if available (`@prefactor/langchain`, `@prefactor/ai`, `@prefactor/openclaw`).
-4. If no matching adapter package exists, use `skills/create-provider-package-with-core/SKILL.md`.
-5. Instrument the existing agent with `skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md`.
+4. For adapter-style instrumentation (`@prefactor/langchain` or `@prefactor/ai`), keep `init`, `withSpan`, and `shutdown` imports from that same adapter package (or pass an explicit tracer when using core `withSpan`).
+5. If no matching adapter package exists, use `skills/create-provider-package-with-core/SKILL.md`.
+6. Instrument the existing agent with `skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md`.

--- a/skills/bootstrap-existing-agent-with-prefactor-cli/SKILL.md
+++ b/skills/bootstrap-existing-agent-with-prefactor-cli/SKILL.md
@@ -106,6 +106,16 @@ Choose package by provider:
 - OpenClaw -> `@prefactor/openclaw`
 - Custom/unsupported provider -> use `skills/create-provider-package-with-core/SKILL.md`
 
+When handing off to SDK instrumentation, import helpers from that selected package directly, for example:
+
+```ts
+import { init, withSpan, shutdown } from '@prefactor/ai';
+// or '@prefactor/langchain'
+```
+
+Do not mix adapter `init` with `withSpan`/`shutdown` from `@prefactor/core` unless an explicit tracer is passed.
+This guidance targets adapter-style integrations (`@prefactor/ai`, `@prefactor/langchain`) and does not change `@prefactor/openclaw` plugin runtime behavior.
+
 If you have identified and selected an existing package, use `skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md`
 
 ## Runtime Environment Variables

--- a/skills/create-provider-package-with-core/SKILL.md
+++ b/skills/create-provider-package-with-core/SKILL.md
@@ -49,6 +49,7 @@ Use this package surface:
 ## 3) Implement instrumentation with core primitives
 
 - Depend on `@prefactor/core` for tracing, context propagation, config, transport helpers.
+- If your adapter exposes helper APIs like `init` + `withSpan`, keep them bound to the same tracer source; if calling core `withSpan` outside adapter helpers, pass an explicit tracer.
 - Wrap provider execution paths in context (`SpanContext.runAsync(...)`) so parent/child spans remain intact.
 - Capture inputs/outputs and usage metadata when available; apply truncation/redaction safeguards.
 - On errors, record span failure data and rethrow the original error.

--- a/skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md
+++ b/skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md
@@ -64,6 +64,18 @@ Recommended sequence when unsupported:
   - LangChain -> `@prefactor/langchain`
   - AI SDK -> `@prefactor/ai`
   - OpenClaw -> `@prefactor/openclaw`
+- Import `init`, `withSpan`, and `shutdown` from the same selected adapter package (`@prefactor/ai` or `@prefactor/langchain`) when an adapter exists.
+- Do not mix adapter `init` with `withSpan`/`shutdown` imported from `@prefactor/core` unless you pass an explicit tracer to `withSpan`.
+- Why: mixed helper imports can lead to `No active tracer found` (for example with nested package instances), which drops manual custom spans.
+- Keep imports package-local and explicit, for example:
+
+```ts
+import { init, withSpan, shutdown } from '@prefactor/ai';
+// or
+import { init, withSpan, shutdown } from '@prefactor/langchain';
+```
+
+- This mixed-import tracer risk applies to adapter-style flows (`@prefactor/ai`, `@prefactor/langchain`) and not to the `@prefactor/openclaw` plugin runtime model.
 - If a built-in adapter does not exist, follow `skills/create-provider-package-with-core/SKILL.md`.
 - Keep provider span types package-prefixed (`langchain:*`, `ai-sdk:*`, `openclaw:*`).
 - Run nested work inside active context so parent/child trace trees stay intact.

--- a/skills/instrument-existing-agent-with-prefactor-sdk/references/coding-tool-triggers.md
+++ b/skills/instrument-existing-agent-with-prefactor-sdk/references/coding-tool-triggers.md
@@ -27,6 +27,11 @@ Use these terms in prompts, descriptions, or examples to improve discovery in co
 - prefactor sdk
 - prefactor cli
 - withSpan
+- shutdown
+- no active tracer found
+- same-package tracer
+- captureTools false
+- manual custom span missing
 - openclaw instrumentation
 
 ## Symptom Keywords

--- a/skills/instrument-existing-agent-with-prefactor-sdk/references/instrumentation-checklist.md
+++ b/skills/instrument-existing-agent-with-prefactor-sdk/references/instrumentation-checklist.md
@@ -39,12 +39,33 @@ If no built-in adapter exists for the target provider, use `skills/create-provid
 
 ## Integration
 
+- For adapter-based integrations, import `init`, `withSpan`, and `shutdown` from the same package (`@prefactor/langchain` or `@prefactor/ai`) instead of mixing with `@prefactor/core`.
+- If you must mix packages, pass an explicit tracer to core `withSpan` (`withSpan(getTracer(), options, fn)`).
+- Scope note: this same-package tracer guidance applies to adapter-style integrations, not the `@prefactor/openclaw` plugin runtime.
 - Add one top-level run/agent span per execution.
 - Add child spans around each LLM call and each external tool invocation.
 - Ensure child operations execute inside active context propagation.
 - Keep custom span types package-prefixed (`langchain:*`, `ai-sdk:*`, or `openclaw:*`).
 - Capture token usage and model metadata when available.
 - Capture inputs/outputs with truncation and redaction enabled.
+
+## Same-Package Tracer Verification
+
+Add these checks to prevent manual custom spans from being dropped:
+
+```bash
+# check imports come from one adapter package
+rg "import\s*\{[^}]*\b(init|withSpan|shutdown)\b[^}]*\}\s*from\s*'@prefactor/" src
+
+# optionally flag direct core helper imports in adapter integrations
+rg "import\s*\{[^}]*\b(withSpan|shutdown)\b[^}]*\}\s*from\s*'@prefactor/core'" src
+```
+
+Smoke check in telemetry:
+
+- Add one manual custom span with `withSpan(...)` in app code.
+- Execute one real request.
+- Confirm the manual custom span appears under the expected run tree.
 
 ## Error + Streaming
 
@@ -75,3 +96,9 @@ Then validate one real run in telemetry:
 - Broken tree -> verify child work runs within active span context.
 - Missing final status -> verify `finally` or stream terminal callbacks finish spans.
 - High payload volume -> enable truncation/redaction and capture flags.
+
+## Troubleshooting Matrix
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| only `ai-sdk:llm` appears | middleware tool spans are active but manual spans are not connected to the active tracer | set `captureTools: false` and use manual `withSpan` from `@prefactor/ai` (same adapter package as `init`) |


### PR DESCRIPTION
Add explicit examples showing that `init`, `withSpan`, and
`shutdown` should be imported from the selected adapter package
(`@prefactor/ai`, `@prefactor/langchain`, `@prefactor/openclaw`)
rather than from `@prefactor/core` when an adapter exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated instrumentation guidance with improved best practices for package imports
  * Added troubleshooting matrix and verification checklist for common integration issues
  * Included new diagnostic commands and smoke-test procedures for telemetry validation
  * Expanded reference documentation with additional tool-trigger keywords and fast debug hints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->