### PR TITLE
[PRE-209] Build CLI binaries in CI

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -53,7 +53,7 @@ jobs:
           - os: macos-latest
             artifact: prefactor-bun-darwin-arm64
             bin: prefactor-macos-arm64
-          - os: macos-13
+          - os: macos-15-intel
             artifact: prefactor-bun-darwin-x64
             bin: prefactor-macos-x64
           - os: windows-latest

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -62,6 +62,9 @@ jobs:
           - os: windows-latest
             artifact: prefactor-bun-windows-x64
             bin: prefactor-windows-x64.exe
+          - os: windows-11-arm
+            artifact: prefactor-bun-windows-arm64
+            bin: prefactor-windows-arm64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,76 @@
+name: Release CLI Binaries
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: bun-linux-x64
+            outfile: prefactor-linux-x64
+          - target: bun-linux-arm64
+            outfile: prefactor-linux-arm64
+          - target: bun-darwin-x64
+            outfile: prefactor-macos-x64
+          - target: bun-darwin-arm64
+            outfile: prefactor-macos-arm64
+          - target: bun-windows-x64
+            outfile: prefactor-windows-x64.exe
+          - target: bun-windows-arm64
+            outfile: prefactor-windows-arm64.exe
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - run: |
+          bun build \
+            --compile \
+            --target=${{ matrix.target }} \
+            --minify \
+            packages/cli/src/bin/cli.ts \
+            --outfile dist/cli/${{ matrix.outfile }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prefactor-${{ matrix.target }}
+          path: dist/cli/${{ matrix.outfile }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/cli
+          merge-multiple: true
+      - name: Create versioned release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          prerelease: false
+          files: dist/cli/*
+      - name: Delete canary tag
+        if: github.ref_type != 'tag'
+        run: |
+          git push origin :refs/tags/canary || true
+          git tag -d canary || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create canary release
+        if: github.ref_type != 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: canary
+          prerelease: true
+          files: dist/cli/*

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -74,8 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, smoke-test]
     concurrency:
-      group: ${{ github.workflow }}-canary
-      cancel-in-progress: false
+      group: ${{ github.ref_type != 'tag' && format('{0}-canary', github.repository) || format('{0}-{1}', github.workflow, github.ref) }}
+      cancel-in-progress: ${{ github.ref_type != 'tag' }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -50,6 +50,9 @@ jobs:
           - os: ubuntu-latest
             artifact: prefactor-bun-linux-x64
             bin: prefactor-linux-x64
+          - os: ubuntu-24.04-arm
+            artifact: prefactor-bun-linux-arm64
+            bin: prefactor-linux-arm64
           - os: macos-latest
             artifact: prefactor-bun-darwin-arm64
             bin: prefactor-macos-arm64

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -42,6 +42,34 @@ jobs:
           name: prefactor-${{ matrix.target }}
           path: dist/cli/${{ matrix.outfile }}
 
+  smoke-test:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: prefactor-bun-linux-x64
+            bin: prefactor-linux-x64
+          - os: macos-latest
+            artifact: prefactor-bun-darwin-arm64
+            bin: prefactor-macos-arm64
+          - os: windows-latest
+            artifact: prefactor-bun-windows-x64
+            bin: prefactor-windows-x64.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+      - name: Run smoke test (unix)
+        if: runner.os != 'Windows'
+        run: |
+          chmod +x ${{ matrix.bin }}
+          ./${{ matrix.bin }} --version
+      - name: Run smoke test (windows)
+        if: runner.os == 'Windows'
+        run: .\${{ matrix.bin }} --version
+
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -72,7 +72,10 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, smoke-test]
+    concurrency:
+      group: ${{ github.workflow }}-canary
+      cancel-in-progress: false
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
@@ -98,5 +101,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: canary
+          target_commitish: ${{ github.sha }}
           prerelease: true
           files: dist/cli/*

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -53,6 +53,9 @@ jobs:
           - os: macos-latest
             artifact: prefactor-bun-darwin-arm64
             bin: prefactor-macos-arm64
+          - os: macos-13
+            artifact: prefactor-bun-darwin-x64
+            bin: prefactor-macos-x64
           - os: windows-latest
             artifact: prefactor-bun-windows-x64
             bin: prefactor-windows-x64.exe

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -62,11 +62,9 @@ jobs:
           files: dist/cli/*
       - name: Delete canary tag
         if: github.ref_type != 'tag'
-        run: |
-          git push origin :refs/tags/canary || true
-          git tag -d canary || true
+        run: gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/canary || true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create canary release
         if: github.ref_type != 'tag'
         uses: softprops/action-gh-release@v2

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
   "author": "Prefactor",
   "license": "MIT",
   "dependencies": {
-    "@prefactor/core": "0.3.1",
+    "@prefactor/core": "workspace:*",
     "@prefactor/pfid": "^0.1.0",
     "commander": "^14.0.1",
     "zod": "^4.0.0"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-cli.yml` to build standalone Bun executables for all 6 target platforms (linux/darwin/windows × x64/arm64)
- On pushes to `main` or PRs: builds binaries and publishes/overwrites a `canary` prerelease
- On version tag pushes (e.g. `v0.0.3`): builds binaries and publishes a versioned GitHub Release
- Cross-compilation runs entirely on `ubuntu-latest` — no per-platform runners needed

## Test plan
- [ ] Open a PR targeting `main` → confirm 6 matrix build jobs run and canary release is updated
- [ ] Push directly to `main` → same canary release flow
- [ ] Push a version tag (e.g. `v0.0.3`) → confirm versioned release created with 6 binary assets
- [ ] Download binary for local platform, run `./prefactor --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated multi-platform CLI build and distribution (Windows, macOS, Linux; x64 & ARM)
  * Automated smoke tests validating each built CLI binary
  * Automatic publishing: versioned releases for tagged builds and canary prereleases for non-tagged changes, with concurrency and PR-gating to prevent unintended releases

* **Chores**
  * Updated dependency linkage for the CLI package
<!-- end of auto-generated comment: release notes by coderabbit.ai -->