### PR TITLE
[PRE-219] expose tool span schemas in typescript AI SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,5 @@ docs/plans/
 # Prefactor CLI profile
 prefactor.json
 .agents/
-.deslopify/
 .desloppify/
 .claude/skills/desloppify/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,7 @@ docs/plans/
 
 # Prefactor CLI profile
 prefactor.json
+.agents/
+.deslopify/
+.desloppify/
 .claude/skills/desloppify/SKILL.md

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/ai": {
       "name": "@prefactor/ai",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@prefactor/pfid": "^0.1.0",
       },
@@ -44,7 +44,7 @@
         "prefactor": "dist/bin/cli.js",
       },
       "dependencies": {
-        "@prefactor/core": "0.3.1",
+        "@prefactor/core": "workspace:*",
         "@prefactor/pfid": "^0.1.0",
         "commander": "^14.0.1",
         "zod": "^4.0.0",
@@ -55,7 +55,7 @@
     },
     "packages/core": {
       "name": "@prefactor/core",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@prefactor/pfid": "^0.1.0",
       },
@@ -91,7 +91,7 @@
     },
   },
   "packages": {
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.15.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-TH4utu23Ix8ec34srBHmDD4p3HI0cYleS1jN9lghRczPfhFlMBNrQgZWeBBe12DWy27L11eIrtciY2MXFSEiDg=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q=="],
 
@@ -113,65 +113,65 @@
 
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
-    "@aws-sdk/client-bedrock": ["@aws-sdk/client-bedrock@3.1006.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.19", "@aws-sdk/credential-provider-node": "^3.972.19", "@aws-sdk/middleware-host-header": "^3.972.7", "@aws-sdk/middleware-logger": "^3.972.7", "@aws-sdk/middleware-recursion-detection": "^3.972.7", "@aws-sdk/middleware-user-agent": "^3.972.20", "@aws-sdk/region-config-resolver": "^3.972.7", "@aws-sdk/token-providers": "3.1006.0", "@aws-sdk/types": "^3.973.5", "@aws-sdk/util-endpoints": "^3.996.4", "@aws-sdk/util-user-agent-browser": "^3.972.7", "@aws-sdk/util-user-agent-node": "^3.973.5", "@smithy/config-resolver": "^4.4.10", "@smithy/core": "^3.23.9", "@smithy/fetch-http-handler": "^5.3.13", "@smithy/hash-node": "^4.2.11", "@smithy/invalid-dependency": "^4.2.11", "@smithy/middleware-content-length": "^4.2.11", "@smithy/middleware-endpoint": "^4.4.23", "@smithy/middleware-retry": "^4.4.40", "@smithy/middleware-serde": "^4.2.12", "@smithy/middleware-stack": "^4.2.11", "@smithy/node-config-provider": "^4.3.11", "@smithy/node-http-handler": "^4.4.14", "@smithy/protocol-http": "^5.3.11", "@smithy/smithy-client": "^4.12.3", "@smithy/types": "^4.13.0", "@smithy/url-parser": "^4.2.11", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.39", "@smithy/util-defaults-mode-node": "^4.2.42", "@smithy/util-endpoints": "^3.3.2", "@smithy/util-middleware": "^4.2.11", "@smithy/util-retry": "^4.2.11", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-CWUrrlWaFDYZIK2rNIa9FUVn3wC3lZszz0r6bq5yRiRj1P+dSd+ZpGdlRYDAi6Nq9dsainEXdpadiuUwzL6YZQ=="],
+    "@aws-sdk/client-bedrock": ["@aws-sdk/client-bedrock@3.1010.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.20", "@aws-sdk/credential-provider-node": "^3.972.21", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.21", "@aws-sdk/region-config-resolver": "^3.972.8", "@aws-sdk/token-providers": "3.1010.0", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.7", "@smithy/config-resolver": "^4.4.11", "@smithy/core": "^3.23.11", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.25", "@smithy/middleware-retry": "^4.4.42", "@smithy/middleware-serde": "^4.2.14", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.4.16", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.5", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.41", "@smithy/util-defaults-mode-node": "^4.2.44", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-H6hGJpya4x7bHGn8hwrxx/5DECIF1m2550Qg9MB55wNqbYqRaANzsuRAop0mCSSt4Nw2bZYkFiPHrujh2/Zc/w=="],
 
-    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1006.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.19", "@aws-sdk/credential-provider-node": "^3.972.19", "@aws-sdk/eventstream-handler-node": "^3.972.10", "@aws-sdk/middleware-eventstream": "^3.972.7", "@aws-sdk/middleware-host-header": "^3.972.7", "@aws-sdk/middleware-logger": "^3.972.7", "@aws-sdk/middleware-recursion-detection": "^3.972.7", "@aws-sdk/middleware-user-agent": "^3.972.20", "@aws-sdk/middleware-websocket": "^3.972.12", "@aws-sdk/region-config-resolver": "^3.972.7", "@aws-sdk/token-providers": "3.1006.0", "@aws-sdk/types": "^3.973.5", "@aws-sdk/util-endpoints": "^3.996.4", "@aws-sdk/util-user-agent-browser": "^3.972.7", "@aws-sdk/util-user-agent-node": "^3.973.5", "@smithy/config-resolver": "^4.4.10", "@smithy/core": "^3.23.9", "@smithy/eventstream-serde-browser": "^4.2.11", "@smithy/eventstream-serde-config-resolver": "^4.3.11", "@smithy/eventstream-serde-node": "^4.2.11", "@smithy/fetch-http-handler": "^5.3.13", "@smithy/hash-node": "^4.2.11", "@smithy/invalid-dependency": "^4.2.11", "@smithy/middleware-content-length": "^4.2.11", "@smithy/middleware-endpoint": "^4.4.23", "@smithy/middleware-retry": "^4.4.40", "@smithy/middleware-serde": "^4.2.12", "@smithy/middleware-stack": "^4.2.11", "@smithy/node-config-provider": "^4.3.11", "@smithy/node-http-handler": "^4.4.14", "@smithy/protocol-http": "^5.3.11", "@smithy/smithy-client": "^4.12.3", "@smithy/types": "^4.13.0", "@smithy/url-parser": "^4.2.11", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.39", "@smithy/util-defaults-mode-node": "^4.2.42", "@smithy/util-endpoints": "^3.3.2", "@smithy/util-middleware": "^4.2.11", "@smithy/util-retry": "^4.2.11", "@smithy/util-stream": "^4.5.17", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-xoReIImKWGEgI5+44ZqADIfjSQTx367d3wkH1kX8ZZNe70mUQxXDzLp1iWBk4FLjQyTnv0J0vMIvhSHVfvFxXA=="],
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1010.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.20", "@aws-sdk/credential-provider-node": "^3.972.21", "@aws-sdk/eventstream-handler-node": "^3.972.11", "@aws-sdk/middleware-eventstream": "^3.972.8", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.21", "@aws-sdk/middleware-websocket": "^3.972.13", "@aws-sdk/region-config-resolver": "^3.972.8", "@aws-sdk/token-providers": "3.1010.0", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.7", "@smithy/config-resolver": "^4.4.11", "@smithy/core": "^3.23.11", "@smithy/eventstream-serde-browser": "^4.2.12", "@smithy/eventstream-serde-config-resolver": "^4.3.12", "@smithy/eventstream-serde-node": "^4.2.12", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.25", "@smithy/middleware-retry": "^4.4.42", "@smithy/middleware-serde": "^4.2.14", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.4.16", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.5", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.41", "@smithy/util-defaults-mode-node": "^4.2.44", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-stream": "^4.5.19", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-+w0fLPL/OjW2SAa7oADu5LmJgbzPTnDCduwcmFnhDUXaeKdyq++BTOX+bqn3SxZ8FnEc8TrfOYAfx66hf7tKdA=="],
 
-    "@aws-sdk/core": ["@aws-sdk/core@3.973.19", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@aws-sdk/xml-builder": "^3.972.10", "@smithy/core": "^3.23.9", "@smithy/node-config-provider": "^4.3.11", "@smithy/property-provider": "^4.2.11", "@smithy/protocol-http": "^5.3.11", "@smithy/signature-v4": "^5.3.11", "@smithy/smithy-client": "^4.12.3", "@smithy/types": "^4.13.0", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.11", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-56KePyOcZnKTWCd89oJS1G6j3HZ9Kc+bh/8+EbvtaCCXdP6T7O7NzCiPuHRhFLWnzXIaXX3CxAz0nI5My9spHQ=="],
+    "@aws-sdk/core": ["@aws-sdk/core@3.973.20", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@aws-sdk/xml-builder": "^3.972.11", "@smithy/core": "^3.23.11", "@smithy/node-config-provider": "^4.3.12", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/signature-v4": "^5.3.12", "@smithy/smithy-client": "^4.12.5", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA=="],
 
-    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.17", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/types": "^3.973.5", "@smithy/property-provider": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-MBAMW6YELzE1SdkOniqr51mrjapQUv8JXSGxtwRjQV0mwVDutVsn22OPAUt4RcLRvdiHQmNBDEFP9iTeSVCOlA=="],
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA=="],
 
-    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.19", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/types": "^3.973.5", "@smithy/fetch-http-handler": "^5.3.13", "@smithy/node-http-handler": "^4.4.14", "@smithy/property-provider": "^4.2.11", "@smithy/protocol-http": "^5.3.11", "@smithy/smithy-client": "^4.12.3", "@smithy/types": "^4.13.0", "@smithy/util-stream": "^4.5.17", "tslib": "^2.6.2" } }, "sha512-9EJROO8LXll5a7eUFqu48k6BChrtokbmgeMWmsH7lBb6lVbtjslUYz/ShLi+SHkYzTomiGBhmzTW7y+H4BxsnA=="],
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.20", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/types": "^3.973.6", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/node-http-handler": "^4.4.16", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.5", "@smithy/types": "^4.13.1", "@smithy/util-stream": "^4.5.19", "tslib": "^2.6.2" } }, "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA=="],
 
-    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/credential-provider-env": "^3.972.17", "@aws-sdk/credential-provider-http": "^3.972.19", "@aws-sdk/credential-provider-login": "^3.972.18", "@aws-sdk/credential-provider-process": "^3.972.17", "@aws-sdk/credential-provider-sso": "^3.972.18", "@aws-sdk/credential-provider-web-identity": "^3.972.18", "@aws-sdk/nested-clients": "^3.996.8", "@aws-sdk/types": "^3.973.5", "@smithy/credential-provider-imds": "^4.2.11", "@smithy/property-provider": "^4.2.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-vthIAXJISZnj2576HeyLBj4WTeX+I7PwWeRkbOa0mVX39K13SCGxCgOFuKj2ytm9qTlLOmXe4cdEnroteFtJfw=="],
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.20", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/credential-provider-env": "^3.972.18", "@aws-sdk/credential-provider-http": "^3.972.20", "@aws-sdk/credential-provider-login": "^3.972.20", "@aws-sdk/credential-provider-process": "^3.972.18", "@aws-sdk/credential-provider-sso": "^3.972.20", "@aws-sdk/credential-provider-web-identity": "^3.972.20", "@aws-sdk/nested-clients": "^3.996.10", "@aws-sdk/types": "^3.973.6", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA=="],
 
-    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/nested-clients": "^3.996.8", "@aws-sdk/types": "^3.973.5", "@smithy/property-provider": "^4.2.11", "@smithy/protocol-http": "^5.3.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-kINzc5BBxdYBkPZ0/i1AMPMOk5b5QaFNbYMElVw5QTX13AKj6jcxnv/YNl9oW9mg+Y08ti19hh01HhyEAxsSJQ=="],
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.20", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/nested-clients": "^3.996.10", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw=="],
 
-    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.19", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.17", "@aws-sdk/credential-provider-http": "^3.972.19", "@aws-sdk/credential-provider-ini": "^3.972.18", "@aws-sdk/credential-provider-process": "^3.972.17", "@aws-sdk/credential-provider-sso": "^3.972.18", "@aws-sdk/credential-provider-web-identity": "^3.972.18", "@aws-sdk/types": "^3.973.5", "@smithy/credential-provider-imds": "^4.2.11", "@smithy/property-provider": "^4.2.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-yDWQ9dFTr+IMxwanFe7+tbN5++q8psZBjlUwOiCXn1EzANoBgtqBwcpYcHaMGtn0Wlfj4NuXdf2JaEx1lz5RaQ=="],
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.21", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.18", "@aws-sdk/credential-provider-http": "^3.972.20", "@aws-sdk/credential-provider-ini": "^3.972.20", "@aws-sdk/credential-provider-process": "^3.972.18", "@aws-sdk/credential-provider-sso": "^3.972.20", "@aws-sdk/credential-provider-web-identity": "^3.972.20", "@aws-sdk/types": "^3.973.6", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA=="],
 
-    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.17", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/types": "^3.973.5", "@smithy/property-provider": "^4.2.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-c8G8wT1axpJDgaP3xzcy+q8Y1fTi9A2eIQJvyhQ9xuXrUZhlCfXbC0vM9bM1CUXiZppFQ1p7g0tuUMvil/gCPg=="],
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA=="],
 
-    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/nested-clients": "^3.996.8", "@aws-sdk/token-providers": "3.1005.0", "@aws-sdk/types": "^3.973.5", "@smithy/property-provider": "^4.2.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-YHYEfj5S2aqInRt5ub8nDOX8vAxgMvd84wm2Y3WVNfFa/53vOv9T7WOAqXI25qjj3uEcV46xxfqdDQk04h5XQA=="],
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.20", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/nested-clients": "^3.996.10", "@aws-sdk/token-providers": "3.1009.0", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA=="],
 
-    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/nested-clients": "^3.996.8", "@aws-sdk/types": "^3.973.5", "@smithy/property-provider": "^4.2.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-OqlEQpJ+J3T5B96qtC1zLLwkBloechP+fezKbCH0sbd2cCc0Ra55XpxWpk/hRj69xAOYtHvoC4orx6eTa4zU7g=="],
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.20", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/nested-clients": "^3.996.10", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA=="],
 
-    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@smithy/eventstream-codec": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-g2Z9s6Y4iNh0wICaEqutgYgt/Pmhv5Ev9G3eKGFe2w9VuZDhc76vYdop6I5OocmpHV79d4TuLG+JWg5rQIVDVA=="],
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/eventstream-codec": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-2IrLrOruRr1NhTK0vguBL1gCWv1pu4bf4KaqpsA+/vCJpFEbvXFawn71GvCzk1wyjnDUsemtKypqoKGv4cSGbA=="],
 
-    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-VWndapHYCfwLgPpCb/xwlMKG4imhFzKJzZcKOEioGn7OHY+6gdr0K7oqy1HZgbLa3ACznZ9fku+DzmAi8fUC0g=="],
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ=="],
 
-    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ=="],
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ=="],
 
-    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w=="],
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA=="],
 
-    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ=="],
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA=="],
 
-    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.20", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/types": "^3.973.5", "@aws-sdk/util-endpoints": "^3.996.4", "@smithy/core": "^3.23.9", "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "@smithy/util-retry": "^4.2.11", "tslib": "^2.6.2" } }, "sha512-3kNTLtpUdeahxtnJRnj/oIdLAUdzTfr9N40KtxNhtdrq+Q1RPMdCJINRXq37m4t5+r3H70wgC3opW46OzFcZYA=="],
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.21", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@smithy/core": "^3.23.11", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-retry": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg=="],
 
-    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.12", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@aws-sdk/util-format-url": "^3.972.7", "@smithy/eventstream-codec": "^4.2.11", "@smithy/eventstream-serde-browser": "^4.2.11", "@smithy/fetch-http-handler": "^5.3.13", "@smithy/protocol-http": "^5.3.11", "@smithy/signature-v4": "^5.3.11", "@smithy/types": "^4.13.0", "@smithy/util-base64": "^4.3.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-iyPP6FVDKe/5wy5ojC0akpDFG1vX3FeCUU47JuwN8xfvT66xlEI8qUJZPtN55TJVFzzWZJpWL78eqUE31md08Q=="],
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-format-url": "^3.972.8", "@smithy/eventstream-codec": "^4.2.12", "@smithy/eventstream-serde-browser": "^4.2.12", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/protocol-http": "^5.3.12", "@smithy/signature-v4": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A=="],
 
-    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.996.8", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.19", "@aws-sdk/middleware-host-header": "^3.972.7", "@aws-sdk/middleware-logger": "^3.972.7", "@aws-sdk/middleware-recursion-detection": "^3.972.7", "@aws-sdk/middleware-user-agent": "^3.972.20", "@aws-sdk/region-config-resolver": "^3.972.7", "@aws-sdk/types": "^3.973.5", "@aws-sdk/util-endpoints": "^3.996.4", "@aws-sdk/util-user-agent-browser": "^3.972.7", "@aws-sdk/util-user-agent-node": "^3.973.5", "@smithy/config-resolver": "^4.4.10", "@smithy/core": "^3.23.9", "@smithy/fetch-http-handler": "^5.3.13", "@smithy/hash-node": "^4.2.11", "@smithy/invalid-dependency": "^4.2.11", "@smithy/middleware-content-length": "^4.2.11", "@smithy/middleware-endpoint": "^4.4.23", "@smithy/middleware-retry": "^4.4.40", "@smithy/middleware-serde": "^4.2.12", "@smithy/middleware-stack": "^4.2.11", "@smithy/node-config-provider": "^4.3.11", "@smithy/node-http-handler": "^4.4.14", "@smithy/protocol-http": "^5.3.11", "@smithy/smithy-client": "^4.12.3", "@smithy/types": "^4.13.0", "@smithy/url-parser": "^4.2.11", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.39", "@smithy/util-defaults-mode-node": "^4.2.42", "@smithy/util-endpoints": "^3.3.2", "@smithy/util-middleware": "^4.2.11", "@smithy/util-retry": "^4.2.11", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-6HlLm8ciMW8VzfB80kfIx16PBA9lOa9Dl+dmCBi78JDhvGlx3I7Rorwi5PpVRkL31RprXnYna3yBf6UKkD/PqA=="],
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.996.10", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.20", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.21", "@aws-sdk/region-config-resolver": "^3.972.8", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.7", "@smithy/config-resolver": "^4.4.11", "@smithy/core": "^3.23.11", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.25", "@smithy/middleware-retry": "^4.4.42", "@smithy/middleware-serde": "^4.2.14", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.4.16", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.5", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.41", "@smithy/util-defaults-mode-node": "^4.2.44", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w=="],
 
-    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@smithy/config-resolver": "^4.4.10", "@smithy/node-config-provider": "^4.3.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA=="],
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/config-resolver": "^4.4.11", "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw=="],
 
-    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1006.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/nested-clients": "^3.996.8", "@aws-sdk/types": "^3.973.5", "@smithy/property-provider": "^4.2.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-eCBaQI1w5PcliOdh8Y0YONOim2zNSTEK4E7gXYC4vIqiT/lzVODIFxmpc8oOBLPSANzcr9daIPPtjQ2C75dLFg=="],
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1010.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/nested-clients": "^3.996.10", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-nR4Iu7+qOUPgnzTpdikOL4cT70R5YRdeo6JQJ5678qv23OwWk3PgJL9BoXtPu2UyAuXNX58BQc7cpYl21sKAoA=="],
 
-    "@aws-sdk/types": ["@aws-sdk/types@3.973.5", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ=="],
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
 
-    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.4", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@smithy/types": "^4.13.0", "@smithy/url-parser": "^4.2.11", "@smithy/util-endpoints": "^3.3.2", "tslib": "^2.6.2" } }, "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA=="],
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.5", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-endpoints": "^3.3.3", "tslib": "^2.6.2" } }, "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw=="],
 
-    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@smithy/querystring-builder": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-V+PbnWfUl93GuFwsOHsAq7hY/fnm9kElRqR8IexIJr5Rvif9e614X5sGSyz3mVSf1YAZ+VTy63W1/pGdA55zyA=="],
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
 
-    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.5", "@smithy/types": "^4.13.0", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw=="],
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/types": "^4.13.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA=="],
 
-    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.5", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.20", "@aws-sdk/types": "^3.973.5", "@smithy/node-config-provider": "^4.3.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-Dyy38O4GeMk7UQ48RupfHif//gqnOPbq/zlvRssc11E2mClT+aUfc3VS2yD8oLtzqO3RsqQ9I3gOBB4/+HjPOw=="],
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.7", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.21", "@aws-sdk/types": "^3.973.6", "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA=="],
 
-    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.10", "", { "dependencies": { "@smithy/types": "^4.13.0", "fast-xml-parser": "5.4.1", "tslib": "^2.6.2" } }, "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA=="],
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.11", "", { "dependencies": { "@smithy/types": "^4.13.1", "fast-xml-parser": "5.4.1", "tslib": "^2.6.2" } }, "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ=="],
 
-    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
 
-    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
 
@@ -191,7 +191,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
 
-    "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@buape/carbon": ["@buape/carbon@0.0.0-beta-20260216184201", "", { "dependencies": { "@types/node": "^25.0.9", "discord-api-types": "0.38.37" }, "optionalDependencies": { "@cloudflare/workers-types": "4.20260120.0", "@discordjs/voice": "0.19.0", "@hono/node-server": "1.19.9", "@types/bun": "1.3.9", "@types/ws": "8.18.1", "ws": "8.19.0" } }, "sha512-u5mgYcigfPVqT7D9gVTGd+3YSflTreQmrWog7ORbb0z5w9eT8ft4rJOdw9fGwr75zMu9kXpSBaAcY2eZoJFSdA=="],
 
@@ -211,15 +211,15 @@
 
     "@discordjs/voice": ["@discordjs/voice@0.19.1", "", { "dependencies": { "@snazzah/davey": "^0.1.9", "@types/ws": "^8.18.1", "discord-api-types": "^0.38.41", "prism-media": "^1.3.5", "tslib": "^2.8.1", "ws": "^8.19.0" } }, "sha512-XYbFVyUBB7zhRvrjREfiWDwio24nEp/vFaVe6u9aBIC5UYuT7HvoMt8LgNfZ5hOyaCW0flFr72pkhUGz+gWw4Q=="],
 
-    "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+    "@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
 
     "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
 
-    "@google/genai": ["@google/genai@1.44.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A=="],
+    "@google/genai": ["@google/genai@1.45.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-+sNRWhKiRibVgc4OKi7aBJJ0A7RcoVD8tGG+eFkqxAWRjASDW+ktS9lLwTDnAxZICzCVoeAdu8dYLJVTX60N9w=="],
 
     "@grammyjs/runner": ["@grammyjs/runner@2.0.3", "", { "dependencies": { "abort-controller": "^3.0.0" }, "peerDependencies": { "grammy": "^1.13.1" } }, "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A=="],
 
@@ -234,8 +234,6 @@
     "@homebridge/ciao": ["@homebridge/ciao@1.3.5", "", { "dependencies": { "debug": "^4.4.3", "fast-deep-equal": "^3.1.3", "source-map-support": "^0.5.21", "tslib": "^2.8.1" }, "bin": { "ciao-bcs": "lib/bonjour-conformance-testing.js" } }, "sha512-f7MAw7YuoEYgJEQ1VyRcLHGuVmCpmXi65GVR8CAtPWPqIZf/HFr4vHzVpOfQMpEQw9Pt5uh07guuLt5HE8ruog=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
-
-    "@huggingface/jinja": ["@huggingface/jinja@0.5.6", "", {}, "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -287,17 +285,11 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@keyv/bigmap": ["@keyv/bigmap@1.3.1", "", { "dependencies": { "hashery": "^1.4.0", "hookified": "^1.15.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ=="],
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
-
-    "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
-
-    "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
 
     "@langchain/anthropic": ["@langchain/anthropic@1.3.23", "", { "dependencies": { "@anthropic-ai/sdk": "^0.74.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.1.32" } }, "sha512-iHCUWKXMZcbjdLZ+mohJMo+tH4HXcZXYktEM02xetpwiqi2vaoDeZsiK/A2kEN24b9QbpG0sLueRNtJHn/fAFA=="],
 
@@ -307,7 +299,7 @@
 
     "@langchain/langgraph-checkpoint": ["@langchain/langgraph-checkpoint@1.0.0", "", { "dependencies": { "uuid": "^10.0.0" }, "peerDependencies": { "@langchain/core": "^1.0.1" } }, "sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A=="],
 
-    "@langchain/langgraph-sdk": ["@langchain/langgraph-sdk@1.7.1", "", { "dependencies": { "@types/json-schema": "^7.0.15", "p-queue": "^9.0.1", "p-retry": "^7.1.1", "uuid": "^13.0.0" }, "peerDependencies": { "@angular/core": "^18.0.0 || ^19.0.0 || ^20.0.0", "@langchain/core": "^1.1.16", "@langchain/react": "*", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@angular/core", "@langchain/core", "@langchain/react", "svelte", "vue"] }, "sha512-U4odaCLxh2eDwym1egzhs/Sv5wPUNqPVV+oOiQw4ACVT4N7GTsLVlvAJlb8jfIlfgjnqkKnaX65ZSA3sFq6hxA=="],
+    "@langchain/langgraph-sdk": ["@langchain/langgraph-sdk@1.7.2", "", { "dependencies": { "@types/json-schema": "^7.0.15", "p-queue": "^9.0.1", "p-retry": "^7.1.1", "uuid": "^13.0.0" }, "peerDependencies": { "@angular/core": "^18.0.0 || ^19.0.0 || ^20.0.0", "@langchain/core": "^1.1.16", "react": "^18 || ^19", "react-dom": "^18 || ^19", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@angular/core", "@langchain/core", "react", "react-dom", "svelte", "vue"] }, "sha512-8ad5OTwqc15J/DxLNJYLn3IC2mpfow09nxJdszxhwm3KgsolGZIUV6g7m67C2p4j3cbQZD5USHt3hKEL0ahqoA=="],
 
     "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.59.0", "", { "dependencies": { "axios": "~1.13.3", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA=="],
 
@@ -351,125 +343,49 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.57.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.57.1" } }, "sha512-WXsBbkNWOObFGHkhixaT8GXJpHDd3+fn8QntYF+4R8Sa9WB90ENXWidO6b7vcKX+JX0jjO5dIsQxmzosARJKlg=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.58.0", "", { "dependencies": { "@mariozechner/pi-ai": "^0.58.0" } }, "sha512-zhkwx3Wdo27snVfnJWi7l+wyU4XlazkeunTtz4e500GC+ufGOp4C3aIf0XiO5ZOtTE/0lvUiG2bWULR/i4lgUQ=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.57.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Bd/J4a3YpdzJVyHLih0vDSdB0QPL4ti0XsAwtHOK/8eVhB0fHM1CpcgIrcBFJ23TMcKXMi0qamz18ERfp8tmgg=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.58.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-3TrkJ9QcBYFPo4NxYluhd+JQ4M+98RaEkNPMrLFU4wK4GMFVtsL3kp1YJ/oj7X0eqKuuDKbHj6MdoMZeT2TCvA=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.57.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.57.1", "@mariozechner/pi-ai": "^0.57.1", "@mariozechner/pi-tui": "^0.57.1", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-u5MQEduj68rwVIsRsqrWkJYiJCyPph/a6bMoJAQKo1sb+Pc17Y/ojwa+wGssnUMjEB38AQKofWTVe8NFEpSWNw=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.58.0", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.58.0", "@mariozechner/pi-ai": "^0.58.0", "@mariozechner/pi-tui": "^0.58.0", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-aCoqIMfcFWwuZrLC4MC1EnHwUrqo+ppamXlNYk5+nANH8U+51AP8OUqOUqT9NSHO9ZdItheU9wCqt7wPf5Ah8A=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.57.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-cjoRghLbeAHV0tTJeHgZXaryUi5zzBZofeZ7uJun1gztnckLLRjoVeaPTujNlc5BIfyKvFqhh1QWCZng/MXlpg=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.58.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-luRbQlk0ZCbYGCtCrKTqQX0ECKNYPj7OSlxKMXEY0B3bA6s4f/Xj0aLPiKlhsIynC2dPQmijA44ZDfrWFniWwA=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
 
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
     "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
 
-    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.96", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.96", "@napi-rs/canvas-darwin-arm64": "0.1.96", "@napi-rs/canvas-darwin-x64": "0.1.96", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.96", "@napi-rs/canvas-linux-arm64-gnu": "0.1.96", "@napi-rs/canvas-linux-arm64-musl": "0.1.96", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.96", "@napi-rs/canvas-linux-x64-gnu": "0.1.96", "@napi-rs/canvas-linux-x64-musl": "0.1.96", "@napi-rs/canvas-win32-arm64-msvc": "0.1.96", "@napi-rs/canvas-win32-x64-msvc": "0.1.96" } }, "sha512-6NNmNxvoJKeucVjxaaRUt3La2i5jShgiAbaY3G/72s1Vp3U06XPrAIxkAjBxpDcamEn/t+WJ4OOlGmvILo4/Ew=="],
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.97", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.97", "@napi-rs/canvas-darwin-arm64": "0.1.97", "@napi-rs/canvas-darwin-x64": "0.1.97", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97", "@napi-rs/canvas-linux-arm64-gnu": "0.1.97", "@napi-rs/canvas-linux-arm64-musl": "0.1.97", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97", "@napi-rs/canvas-linux-x64-gnu": "0.1.97", "@napi-rs/canvas-linux-x64-musl": "0.1.97", "@napi-rs/canvas-win32-arm64-msvc": "0.1.97", "@napi-rs/canvas-win32-x64-msvc": "0.1.97" } }, "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ=="],
 
-    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.96", "", { "os": "android", "cpu": "arm64" }, "sha512-ew1sPrN3dGdZ3L4FoohPfnjq0f9/Jk7o+wP7HkQZokcXgIUD6FIyICEWGhMYzv53j63wUcPvZeAwgewX58/egg=="],
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.97", "", { "os": "android", "cpu": "arm64" }, "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ=="],
 
-    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.96", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Q/wOXZ5PzTqpdmA5eUOcegCf4Go/zz3aZ5DlzSeDpOjFmfwMKh8EzLAoweQ+mJVagcHQyzoJhaTEnrO68TNyNg=="],
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.97", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw=="],
 
-    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.96", "", { "os": "darwin", "cpu": "x64" }, "sha512-UrXiQz28tQEvGM1qvyptewOAfmUrrd5+wvi6Rzjj2VprZI8iZ2KIvBD2lTTG1bVF95AbeDeG7PJA0D9sLKaOFA=="],
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.97", "", { "os": "darwin", "cpu": "x64" }, "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA=="],
 
-    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.96", "", { "os": "linux", "cpu": "arm" }, "sha512-I90ODxweD8aEP6XKU/NU+biso95MwCtQ2F46dUvhec1HesFi0tq/tAJkYic/1aBSiO/1kGKmSeD1B0duOHhEHQ=="],
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.97", "", { "os": "linux", "cpu": "arm" }, "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw=="],
 
-    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.96", "", { "os": "linux", "cpu": "arm64" }, "sha512-Dx/0+RFV++w3PcRy+4xNXkghhXjA5d0Mw1bs95emn5Llinp1vihMaA6WJt3oYv2LAHc36+gnrhIBsPhUyI2SGw=="],
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.97", "", { "os": "linux", "cpu": "arm64" }, "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w=="],
 
-    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.96", "", { "os": "linux", "cpu": "arm64" }, "sha512-UvOi7fii3IE2KDfEfhh8m+LpzSRvhGK7o1eho99M2M0HTik11k3GX+2qgVx9EtujN3/bhFFS1kSO3+vPMaJ0Mg=="],
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.97", "", { "os": "linux", "cpu": "arm64" }, "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ=="],
 
-    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.96", "", { "os": "linux", "cpu": "none" }, "sha512-MBSukhGCQ5nRtf9NbFYWOU080yqkZU1PbuH4o1ROvB4CbPl12fchDR35tU83Wz8gWIM9JTn99lBn9DenPIv7Ig=="],
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.97", "", { "os": "linux", "cpu": "none" }, "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA=="],
 
-    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.96", "", { "os": "linux", "cpu": "x64" }, "sha512-I/ccu2SstyKiV3HIeVzyBIWfrJo8cN7+MSQZPnabewWV6hfJ2nY7Df2WqOHmobBRUw84uGR6zfQHsUEio/m5Vg=="],
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.97", "", { "os": "linux", "cpu": "x64" }, "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg=="],
 
-    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.96", "", { "os": "linux", "cpu": "x64" }, "sha512-H3uov7qnTl73GDT4h52lAqpJPsl1tIUyNPWJyhQ6gHakohNqqRq3uf80+NEpzcytKGEOENP1wX3yGwZxhjiWEQ=="],
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.97", "", { "os": "linux", "cpu": "x64" }, "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA=="],
 
-    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.96", "", { "os": "win32", "cpu": "arm64" }, "sha512-ATp6Y+djOjYtkfV/VRH7CZ8I1MEtkUQBmKUbuWw5zWEHHqfL0cEcInE4Cxgx7zkNAhEdBbnH8HMVrqNp+/gwxA=="],
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.97", "", { "os": "win32", "cpu": "arm64" }, "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A=="],
 
-    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.96", "", { "os": "win32", "cpu": "x64" }, "sha512-UYGdTltVd+Z8mcIuoqGmAXXUvwH5CLf2M6mIB5B0/JmX5J041jETjqtSYl7gN+aj3k1by/SG6sS0hAwCqyK7zw=="],
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.97", "", { "os": "win32", "cpu": "x64" }, "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
-
-    "@node-llama-cpp/linux-arm64": ["@node-llama-cpp/linux-arm64@3.16.2", "", { "os": "linux", "cpu": [ "x64", "arm64", ] }, "sha512-CxzgPsS84wL3W5sZRgxP3c9iJKEW+USrak1SmX6EAJxW/v9QGzehvT6W/aR1FyfidiIyQtOp3ga0Gg/9xfJPGw=="],
-
-    "@node-llama-cpp/linux-armv7l": ["@node-llama-cpp/linux-armv7l@3.16.2", "", { "os": "linux", "cpu": [ "arm", "x64", ] }, "sha512-9G6W/MkQ/DLwGmpcj143NQ50QJg5gQZfzVf5RYx77VczBqhgwkgYHILekYrOs4xanOeqeJ8jnOnQQSp1YaJZUg=="],
-
-    "@node-llama-cpp/linux-x64": ["@node-llama-cpp/linux-x64@3.16.2", "", { "os": "linux", "cpu": "x64" }, "sha512-OXYf8rVfoDyvN+YrfKk8F9An9a5GOxVIM8OcR1U911tc0oRNf8yfJrQ8KrM75R26gwq0Y6YZwVTP0vRCInwWOw=="],
-
-    "@node-llama-cpp/linux-x64-cuda": ["@node-llama-cpp/linux-x64-cuda@3.16.2", "", { "os": "linux", "cpu": "x64" }, "sha512-LTBQFqjin7tyrLNJz0XWTB5QAHDsZV71/qiiRRjXdBKSZHVVaPLfdgxypGu7ggPeBNsv+MckRXdlH5C7yMtE4A=="],
-
-    "@node-llama-cpp/linux-x64-cuda-ext": ["@node-llama-cpp/linux-x64-cuda-ext@3.16.2", "", { "os": "linux", "cpu": "x64" }, "sha512-47d9myCJauZyzAlN7IK1eIt/4CcBMslF+yHy4q+yJotD/RV/S6qRpK2kGn+ybtdVjkPGNCoPkHKcyla9iIVjbw=="],
-
-    "@node-llama-cpp/linux-x64-vulkan": ["@node-llama-cpp/linux-x64-vulkan@3.16.2", "", { "os": "linux", "cpu": "x64" }, "sha512-HDLAw4ZhwJuhKuF6n4x520yZXAQZahUOXtCGvPubjfpmIOElKrfDvCVlRsthAP0JwcwINzIQlVys3boMIXfBgw=="],
-
-    "@node-llama-cpp/mac-arm64-metal": ["@node-llama-cpp/mac-arm64-metal@3.16.2", "", { "os": "darwin", "cpu": [ "x64", "arm64", ] }, "sha512-nEZ74qB0lUohF88yR741YUrUqz/qD+FJFzUTHj0FwxAynSZCjvwtzEDtavRlh3qd3yLD/0ChNn00/RQ54ISImw=="],
-
-    "@node-llama-cpp/mac-x64": ["@node-llama-cpp/mac-x64@3.16.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-BjA+DgeDt+kRxVMV6kChb9XVXm7U5b90jUif7Z/s6ZXtOOnV6exrTM2W09kbSqAiNhZmctcVY83h2dwNTZ/yIw=="],
-
-    "@node-llama-cpp/win-arm64": ["@node-llama-cpp/win-arm64@3.16.2", "", { "os": "win32", "cpu": [ "x64", "arm64", ] }, "sha512-XHNFQzUjYODtkZjIn4NbQVrBtGB9RI9TpisiALryqfrIqagQmjBh6dmxZWlt5uduKAfT7M2/2vrABGR490FACA=="],
-
-    "@node-llama-cpp/win-x64": ["@node-llama-cpp/win-x64@3.16.2", "", { "os": "win32", "cpu": "x64" }, "sha512-etrivzbyLNVhZlUosFW8JSL0OSiuKQf9qcI3dNdehD907sHquQbBJrG7lXcdL6IecvXySp3oAwCkM87VJ0b3Fg=="],
-
-    "@node-llama-cpp/win-x64-cuda": ["@node-llama-cpp/win-x64-cuda@3.16.2", "", { "os": "win32", "cpu": "x64" }, "sha512-jStDELHrU3rKQMOk5Hs5bWEazyjE2hzHwpNf6SblOpaGkajM/HJtxEZoL0mLHJx5qeXs4oOVkr7AzuLy0WPpNA=="],
-
-    "@node-llama-cpp/win-x64-cuda-ext": ["@node-llama-cpp/win-x64-cuda-ext@3.16.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sdv4Kzn9bOQWNBRvw6B/zcn8dQRfZhjIHv5AfDBIOfRlSCgjebFpBeYUoU4wZPpjr3ISwcqO5MEWsw+AbUdV3Q=="],
-
-    "@node-llama-cpp/win-x64-vulkan": ["@node-llama-cpp/win-x64-vulkan@3.16.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9xuHFCOhCQjZgQSFrk79EuSKn9nGWt/SAq/3wujQSQLtgp8jGdtZgwcmuDUoemInf10en2dcOmEt7t8dQdC3XA=="],
-
-    "@octokit/app": ["@octokit/app@16.1.2", "", { "dependencies": { "@octokit/auth-app": "^8.1.2", "@octokit/auth-unauthenticated": "^7.0.3", "@octokit/core": "^7.0.6", "@octokit/oauth-app": "^8.0.3", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.0.0" } }, "sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ=="],
-
-    "@octokit/auth-app": ["@octokit/auth-app@8.2.0", "", { "dependencies": { "@octokit/auth-oauth-app": "^9.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "toad-cache": "^3.7.0", "universal-github-app-jwt": "^2.2.0", "universal-user-agent": "^7.0.0" } }, "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g=="],
-
-    "@octokit/auth-oauth-app": ["@octokit/auth-oauth-app@9.0.3", "", { "dependencies": { "@octokit/auth-oauth-device": "^8.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg=="],
-
-    "@octokit/auth-oauth-device": ["@octokit/auth-oauth-device@8.0.3", "", { "dependencies": { "@octokit/oauth-methods": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw=="],
-
-    "@octokit/auth-oauth-user": ["@octokit/auth-oauth-user@6.0.2", "", { "dependencies": { "@octokit/auth-oauth-device": "^8.0.3", "@octokit/oauth-methods": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A=="],
-
-    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
-
-    "@octokit/auth-unauthenticated": ["@octokit/auth-unauthenticated@7.0.3", "", { "dependencies": { "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0" } }, "sha512-8Jb1mtUdmBHL7lGmop9mU9ArMRUTRhg8vp0T1VtZ4yd9vEm3zcLwmjQkhNEduKawOOORie61xhtYIhTDN+ZQ3g=="],
-
-    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
-
-    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
-
-    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
-
-    "@octokit/oauth-app": ["@octokit/oauth-app@8.0.3", "", { "dependencies": { "@octokit/auth-oauth-app": "^9.0.2", "@octokit/auth-oauth-user": "^6.0.1", "@octokit/auth-unauthenticated": "^7.0.2", "@octokit/core": "^7.0.5", "@octokit/oauth-authorization-url": "^8.0.0", "@octokit/oauth-methods": "^6.0.1", "@types/aws-lambda": "^8.10.83", "universal-user-agent": "^7.0.0" } }, "sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg=="],
-
-    "@octokit/oauth-authorization-url": ["@octokit/oauth-authorization-url@8.0.0", "", {}, "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ=="],
-
-    "@octokit/oauth-methods": ["@octokit/oauth-methods@6.0.2", "", { "dependencies": { "@octokit/oauth-authorization-url": "^8.0.0", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0" } }, "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng=="],
-
-    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
-
-    "@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@12.1.0", "", {}, "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA=="],
-
-    "@octokit/plugin-paginate-graphql": ["@octokit/plugin-paginate-graphql@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ=="],
-
-    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
-
-    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
-
-    "@octokit/plugin-retry": ["@octokit/plugin-retry@8.1.0", "", { "dependencies": { "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": ">=7" } }, "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw=="],
-
-    "@octokit/plugin-throttling": ["@octokit/plugin-throttling@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": "^7.0.0" } }, "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg=="],
-
-    "@octokit/request": ["@octokit/request@10.0.8", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw=="],
-
-    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
-
-    "@octokit/webhooks": ["@octokit/webhooks@14.2.0", "", { "dependencies": { "@octokit/openapi-webhooks-types": "12.1.0", "@octokit/request-error": "^7.0.0", "@octokit/webhooks-methods": "^6.0.0" } }, "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw=="],
-
-    "@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
-
-    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@prefactor/ai": ["@prefactor/ai@workspace:packages/ai"],
 
@@ -503,24 +419,6 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
-    "@reflink/reflink": ["@reflink/reflink@0.1.19", "", { "optionalDependencies": { "@reflink/reflink-darwin-arm64": "0.1.19", "@reflink/reflink-darwin-x64": "0.1.19", "@reflink/reflink-linux-arm64-gnu": "0.1.19", "@reflink/reflink-linux-arm64-musl": "0.1.19", "@reflink/reflink-linux-x64-gnu": "0.1.19", "@reflink/reflink-linux-x64-musl": "0.1.19", "@reflink/reflink-win32-arm64-msvc": "0.1.19", "@reflink/reflink-win32-x64-msvc": "0.1.19" } }, "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA=="],
-
-    "@reflink/reflink-darwin-arm64": ["@reflink/reflink-darwin-arm64@0.1.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA=="],
-
-    "@reflink/reflink-darwin-x64": ["@reflink/reflink-darwin-x64@0.1.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA=="],
-
-    "@reflink/reflink-linux-arm64-gnu": ["@reflink/reflink-linux-arm64-gnu@0.1.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg=="],
-
-    "@reflink/reflink-linux-arm64-musl": ["@reflink/reflink-linux-arm64-musl@0.1.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA=="],
-
-    "@reflink/reflink-linux-x64-gnu": ["@reflink/reflink-linux-x64-gnu@0.1.19", "", { "os": "linux", "cpu": "x64" }, "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw=="],
-
-    "@reflink/reflink-linux-x64-musl": ["@reflink/reflink-linux-x64-musl@0.1.19", "", { "os": "linux", "cpu": "x64" }, "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ=="],
-
-    "@reflink/reflink-win32-arm64-msvc": ["@reflink/reflink-win32-arm64-msvc@0.1.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ=="],
-
-    "@reflink/reflink-win32-x64-msvc": ["@reflink/reflink-win32-x64-msvc@0.1.19", "", { "os": "win32", "cpu": "x64" }, "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w=="],
-
     "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
 
     "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
@@ -537,75 +435,75 @@
 
     "@slack/bolt": ["@slack/bolt@4.6.0", "", { "dependencies": { "@slack/logger": "^4.0.0", "@slack/oauth": "^3.0.4", "@slack/socket-mode": "^2.0.5", "@slack/types": "^2.18.0", "@slack/web-api": "^7.12.0", "axios": "^1.12.0", "express": "^5.0.0", "path-to-regexp": "^8.1.0", "raw-body": "^3", "tsscmp": "^1.0.6" }, "peerDependencies": { "@types/express": "^5.0.0" } }, "sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ=="],
 
-    "@slack/logger": ["@slack/logger@4.0.0", "", { "dependencies": { "@types/node": ">=18.0.0" } }, "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA=="],
+    "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
 
-    "@slack/oauth": ["@slack/oauth@3.0.4", "", { "dependencies": { "@slack/logger": "^4", "@slack/web-api": "^7.10.0", "@types/jsonwebtoken": "^9", "@types/node": ">=18", "jsonwebtoken": "^9" } }, "sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg=="],
+    "@slack/oauth": ["@slack/oauth@3.0.5", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/jsonwebtoken": "^9", "@types/node": ">=18", "jsonwebtoken": "^9" } }, "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A=="],
 
-    "@slack/socket-mode": ["@slack/socket-mode@2.0.5", "", { "dependencies": { "@slack/logger": "^4", "@slack/web-api": "^7.10.0", "@types/node": ">=18", "@types/ws": "^8", "eventemitter3": "^5", "ws": "^8" } }, "sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ=="],
+    "@slack/socket-mode": ["@slack/socket-mode@2.0.6", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/node": ">=18", "@types/ws": "^8", "eventemitter3": "^5", "ws": "^8" } }, "sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ=="],
 
-    "@slack/types": ["@slack/types@2.20.0", "", {}, "sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA=="],
+    "@slack/types": ["@slack/types@2.20.1", "", {}, "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A=="],
 
-    "@slack/web-api": ["@slack/web-api@7.14.1", "", { "dependencies": { "@slack/logger": "^4.0.0", "@slack/types": "^2.20.0", "@types/node": ">=18.0.0", "@types/retry": "0.12.0", "axios": "^1.13.5", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng=="],
+    "@slack/web-api": ["@slack/web-api@7.15.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.13.5", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw=="],
 
-    "@smithy/abort-controller": ["@smithy/abort-controller@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ=="],
+    "@smithy/abort-controller": ["@smithy/abort-controller@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q=="],
 
-    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.10", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.11", "@smithy/types": "^4.13.0", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-endpoints": "^3.3.2", "@smithy/util-middleware": "^4.2.11", "tslib": "^2.6.2" } }, "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg=="],
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.11", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw=="],
 
-    "@smithy/core": ["@smithy/core@3.23.9", "", { "dependencies": { "@smithy/middleware-serde": "^4.2.12", "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-middleware": "^4.2.11", "@smithy/util-stream": "^4.5.17", "@smithy/util-utf8": "^4.2.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ=="],
+    "@smithy/core": ["@smithy/core@3.23.12", "", { "dependencies": { "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-middleware": "^4.2.12", "@smithy/util-stream": "^4.5.20", "@smithy/util-utf8": "^4.2.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w=="],
 
-    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.11", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.11", "@smithy/property-provider": "^4.2.11", "@smithy/types": "^4.13.0", "@smithy/url-parser": "^4.2.11", "tslib": "^2.6.2" } }, "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g=="],
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.12", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/property-provider": "^4.2.12", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg=="],
 
-    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.11", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.13.0", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Sf39Ml0iVX+ba/bgMPxaXWAAFmHqYLTmbjAPfLPLY8CrYkRDEqZdUsKC1OwVMCdJXfAt0v4j49GIJ8DoSYAe6w=="],
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.12", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.13.1", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA=="],
 
-    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.11", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-3rEpo3G6f/nRS7fQDsZmxw/ius6rnlIpz4UX6FlALEzz8JoSxFmdBt0SZnthis+km7sQo6q5/3e+UJcuQivoXA=="],
+    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.12", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A=="],
 
-    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.3.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-XeNIA8tcP/GDWnnKkO7qEm/bg0B/bP9lvIXZBXcGZwZ+VYM8h8k9wuDvUODtdQ2Wcp2RcBkPTCSMmaniVHrMlA=="],
+    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.3.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q=="],
 
-    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.2.11", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-fzbCh18rscBDTQSCrsp1fGcclLNF//nJyhjldsEl/5wCYmgpHblv5JSppQAyQI24lClsFT0wV06N1Porn0IsEw=="],
+    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.2.12", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA=="],
 
-    "@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.11", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-MJ7HcI+jEkqoWT5vp+uoVaAjBrmxBtKhZTeynDRG/seEjJfqyg3SiqMMqyPnAMzmIfLaeJ/uiuSDP/l9AnMy/Q=="],
+    "@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.12", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ=="],
 
-    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.13", "", { "dependencies": { "@smithy/protocol-http": "^5.3.11", "@smithy/querystring-builder": "^4.2.11", "@smithy/types": "^4.13.0", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ=="],
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.15", "", { "dependencies": { "@smithy/protocol-http": "^5.3.12", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A=="],
 
-    "@smithy/hash-node": ["@smithy/hash-node@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A=="],
+    "@smithy/hash-node": ["@smithy/hash-node@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w=="],
 
-    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g=="],
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g=="],
 
     "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
 
-    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.11", "", { "dependencies": { "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw=="],
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.12", "", { "dependencies": { "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA=="],
 
-    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.23", "", { "dependencies": { "@smithy/core": "^3.23.9", "@smithy/middleware-serde": "^4.2.12", "@smithy/node-config-provider": "^4.3.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "@smithy/url-parser": "^4.2.11", "@smithy/util-middleware": "^4.2.11", "tslib": "^2.6.2" } }, "sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw=="],
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.26", "", { "dependencies": { "@smithy/core": "^3.23.12", "@smithy/middleware-serde": "^4.2.15", "@smithy/node-config-provider": "^4.3.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-middleware": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-8Qfikvd2GVKSm8S6IbjfwFlRY9VlMrj0Dp4vTwAuhqbX7NhJKE5DQc2bnfJIcY0B+2YKMDBWfvexbSZeejDgeg=="],
 
-    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.4.40", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.11", "@smithy/protocol-http": "^5.3.11", "@smithy/service-error-classification": "^4.2.11", "@smithy/smithy-client": "^4.12.3", "@smithy/types": "^4.13.0", "@smithy/util-middleware": "^4.2.11", "@smithy/util-retry": "^4.2.11", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA=="],
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.4.43", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/protocol-http": "^5.3.12", "@smithy/service-error-classification": "^4.2.12", "@smithy/smithy-client": "^4.12.6", "@smithy/types": "^4.13.1", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-ZwsifBdyuNHrFGmbc7bAfP2b54+kt9J2rhFd18ilQGAB+GDiP4SrawqyExbB7v455QVR7Psyhb2kjULvBPIhvA=="],
 
-    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.12", "", { "dependencies": { "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng=="],
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.15", "", { "dependencies": { "@smithy/core": "^3.23.12", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg=="],
 
-    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg=="],
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw=="],
 
-    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.11", "", { "dependencies": { "@smithy/property-provider": "^4.2.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg=="],
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.12", "", { "dependencies": { "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw=="],
 
-    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.4.14", "", { "dependencies": { "@smithy/abort-controller": "^4.2.11", "@smithy/protocol-http": "^5.3.11", "@smithy/querystring-builder": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A=="],
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.5.0", "", { "dependencies": { "@smithy/abort-controller": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A=="],
 
-    "@smithy/property-provider": ["@smithy/property-provider@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg=="],
+    "@smithy/property-provider": ["@smithy/property-provider@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A=="],
 
-    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ=="],
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw=="],
 
-    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA=="],
+    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg=="],
 
-    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ=="],
+    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw=="],
 
-    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0" } }, "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw=="],
+    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1" } }, "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ=="],
 
-    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.6", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw=="],
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.7", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw=="],
 
-    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.11", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.11", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ=="],
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.12", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.12", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw=="],
 
-    "@smithy/smithy-client": ["@smithy/smithy-client@4.12.3", "", { "dependencies": { "@smithy/core": "^3.23.9", "@smithy/middleware-endpoint": "^4.4.23", "@smithy/middleware-stack": "^4.2.11", "@smithy/protocol-http": "^5.3.11", "@smithy/types": "^4.13.0", "@smithy/util-stream": "^4.5.17", "tslib": "^2.6.2" } }, "sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw=="],
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.12.6", "", { "dependencies": { "@smithy/core": "^3.23.12", "@smithy/middleware-endpoint": "^4.4.26", "@smithy/middleware-stack": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-stream": "^4.5.20", "tslib": "^2.6.2" } }, "sha512-aib3f0jiMsJ6+cvDnXipBsGDL7ztknYSVqJs1FdN9P+u9tr/VzOR7iygSh6EUOdaBeMCMSh3N0VdyYsG4o91DQ=="],
 
-    "@smithy/types": ["@smithy/types@4.13.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw=="],
+    "@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
 
-    "@smithy/url-parser": ["@smithy/url-parser@4.2.11", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing=="],
+    "@smithy/url-parser": ["@smithy/url-parser@4.2.12", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA=="],
 
     "@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
 
@@ -617,19 +515,19 @@
 
     "@smithy/util-config-provider": ["@smithy/util-config-provider@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ=="],
 
-    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.39", "", { "dependencies": { "@smithy/property-provider": "^4.2.11", "@smithy/smithy-client": "^4.12.3", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ=="],
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.42", "", { "dependencies": { "@smithy/property-provider": "^4.2.12", "@smithy/smithy-client": "^4.12.6", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-0vjwmcvkWAUtikXnWIUOyV6IFHTEeQUYh3JUZcDgcszF+hD/StAsQ3rCZNZEPHgI9kVNcbnyc8P2CBHnwgmcwg=="],
 
-    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.42", "", { "dependencies": { "@smithy/config-resolver": "^4.4.10", "@smithy/credential-provider-imds": "^4.2.11", "@smithy/node-config-provider": "^4.3.11", "@smithy/property-provider": "^4.2.11", "@smithy/smithy-client": "^4.12.3", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A=="],
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.45", "", { "dependencies": { "@smithy/config-resolver": "^4.4.11", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/property-provider": "^4.2.12", "@smithy/smithy-client": "^4.12.6", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-q5dOqqfTgUcLe38TAGiFn9srToKj2YCHJ34QGOLzM+xYLLA+qRZv7N+33kl1MERVusue36ZHnlNaNEvY/PzSrw=="],
 
-    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.3.2", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA=="],
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.3.3", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig=="],
 
     "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
 
-    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.11", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw=="],
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ=="],
 
-    "@smithy/util-retry": ["@smithy/util-retry@4.2.11", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.11", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw=="],
+    "@smithy/util-retry": ["@smithy/util-retry@4.2.12", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ=="],
 
-    "@smithy/util-stream": ["@smithy/util-stream@4.5.17", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.13", "@smithy/node-http-handler": "^4.4.14", "@smithy/types": "^4.13.0", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ=="],
+    "@smithy/util-stream": ["@smithy/util-stream@4.5.20", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.15", "@smithy/node-http-handler": "^4.5.0", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw=="],
 
     "@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
 
@@ -669,8 +567,6 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.4", "", {}, "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA=="],
-
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -678,8 +574,6 @@
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
-
-    "@types/aws-lambda": ["@types/aws-lambda@8.10.161", "", {}, "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ=="],
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
@@ -733,15 +627,13 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+    "agent-base": ["agent-base@8.0.0", "", {}, "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg=="],
 
     "ai": ["ai@6.0.116", "", { "dependencies": { "@ai-sdk/gateway": "3.0.66", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
-    "ansi-escapes": ["ansi-escapes@6.2.1", "", {}, "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -755,8 +647,6 @@
 
     "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
 
-    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
-
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
@@ -768,8 +658,6 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "basic-ftp": ["basic-ftp@5.2.0", "", {}, "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw=="],
-
-    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
@@ -803,23 +691,13 @@
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "chmodrp": ["chmodrp@1.0.2", "", {}, "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w=="],
-
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
-    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
-
-    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
-
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
-    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
-
     "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
-
-    "cmake-js": ["cmake-js@8.0.0", "", { "dependencies": { "debug": "^4.4.3", "fs-extra": "^11.3.3", "node-api-headers": "^1.8.0", "rc": "1.2.8", "semver": "^7.7.3", "tar": "^7.5.6", "url-join": "^4.0.1", "which": "^6.0.0", "yargs": "^17.7.2" }, "bin": { "cmake-js": "bin/cmake-js" } }, "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -841,6 +719,8 @@
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -858,8 +738,6 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
@@ -885,8 +763,6 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
-
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -898,8 +774,6 @@
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "env-var": ["env-var@7.5.0", "", {}, "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -927,21 +801,23 @@
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
-    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
-
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
-    "fast-xml-builder": ["fast-xml-builder@1.1.0", "", { "dependencies": { "path-expression-matcher": "^1.1.2" } }, "sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg=="],
+    "fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.4.1", "", { "dependencies": { "fast-xml-builder": "^1.0.0", "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A=="],
 
@@ -949,17 +825,11 @@
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
-    "file-type": ["file-type@21.3.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA=="],
-
-    "filename-reserved-regex": ["filename-reserved-regex@3.0.0", "", {}, "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="],
-
-    "filenamify": ["filenamify@6.0.0", "", { "dependencies": { "filename-reserved-regex": "^3.0.0" } }, "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ=="],
+    "file-type": ["file-type@21.3.3", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
-
-    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
@@ -969,11 +839,9 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
-    "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
-
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
-    "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+    "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
 
     "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
@@ -991,7 +859,7 @@
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
-    "google-auth-library": ["google-auth-library@10.6.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "7.1.3", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA=="],
+    "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
@@ -1027,7 +895,7 @@
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+    "https-proxy-agent": ["https-proxy-agent@8.0.0", "", { "dependencies": { "agent-base": "8.0.0", "debug": "^4.3.4" } }, "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1039,19 +907,13 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
 
-    "ipull": ["ipull@3.9.5", "", { "dependencies": { "@tinyhttp/content-disposition": "^2.2.0", "async-retry": "^1.3.3", "chalk": "^5.3.0", "ci-info": "^4.0.0", "cli-spinners": "^2.9.2", "commander": "^10.0.0", "eventemitter3": "^5.0.1", "filenamify": "^6.0.0", "fs-extra": "^11.1.1", "is-unicode-supported": "^2.0.0", "lifecycle-utils": "^2.0.1", "lodash.debounce": "^4.0.8", "lowdb": "^7.0.1", "pretty-bytes": "^6.1.0", "pretty-ms": "^8.0.0", "sleep-promise": "^9.1.0", "slice-ansi": "^7.1.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.1.0" }, "optionalDependencies": { "@reflink/reflink": "^0.1.16" }, "bin": { "ipull": "dist/cli/cli.js" } }, "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA=="],
-
     "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
-
-    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-network-error": ["is-network-error@1.3.1", "", {}, "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw=="],
 
@@ -1059,15 +921,13 @@
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
-    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
-
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
-    "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
-
-    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
 
     "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
@@ -1079,11 +939,9 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "json-with-bigint": ["json-with-bigint@3.5.7", "", {}, "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw=="],
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
-
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 
@@ -1095,23 +953,19 @@
 
     "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
-    "koffi": ["koffi@2.15.1", "", {}, "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA=="],
+    "koffi": ["koffi@2.15.2", "", {}, "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g=="],
 
-    "langchain": ["langchain@1.2.31", "", { "dependencies": { "@langchain/langgraph": "^1.1.2", "@langchain/langgraph-checkpoint": "^1.0.0", "langsmith": ">=0.5.0 <1.0.0", "uuid": "^11.1.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.1.32" } }, "sha512-dKafIQKyNUoMlZX7NaEaDt9pqofZbsF2UoJkPrybC99vV9QbUEiLKT0yGdixA3qFHXmsFdJWpu4n4a+B87Q2Zw=="],
+    "langchain": ["langchain@1.2.32", "", { "dependencies": { "@langchain/langgraph": "^1.1.2", "@langchain/langgraph-checkpoint": "^1.0.0", "langsmith": ">=0.5.0 <1.0.0", "uuid": "^11.1.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.1.32" } }, "sha512-LwT0+ClCx9dLDSt8SQpZAdOHLlmcbPJUvUhFgS18boGfKvUFbXom8+xN20wiHMktwB3RB1CRyDLPRMP+tMabMA=="],
 
-    "langsmith": ["langsmith@0.5.9", "", { "dependencies": { "@types/uuid": "^10.0.0", "chalk": "^5.6.2", "console-table-printer": "^2.12.1", "p-queue": "^6.6.2", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai"] }, "sha512-mT88HlYTz7IZzVJP/OM7D6PAR3kzcbPGjYDJpx64ua9WiJXFqQx6YKewxIIxkVSZCb9I/9TiYvPYfZ4rawOdEg=="],
+    "langsmith": ["langsmith@0.5.10", "", { "dependencies": { "@types/uuid": "^10.0.0", "chalk": "^5.6.2", "console-table-printer": "^2.12.1", "p-queue": "^6.6.2", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*", "ws": ">=7" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai", "ws"] }, "sha512-unBdaaD/CqAOLIYjd9kT33FgHUMvHSsyBIPbQa+p/rE/Sv/l4pAC5ISEE79zphxi+vV4qxHqEgqahVXj2Xvz7A=="],
 
     "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d"],
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
-    "lifecycle-utils": ["lifecycle-utils@3.1.1", "", {}, "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg=="],
-
     "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
-
-    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
     "lodash.identity": ["lodash.identity@3.0.0", "", {}, "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q=="],
 
@@ -1133,13 +987,9 @@
 
     "lodash.pickby": ["lodash.pickby@4.6.0", "", {}, "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q=="],
 
-    "log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
-
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
-    "lowdb": ["lowdb@7.0.1", "", { "dependencies": { "steno": "^4.0.2" } }, "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw=="],
-
-    "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
+    "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
 
@@ -1159,11 +1009,7 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
     "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
-
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -1171,29 +1017,21 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "music-metadata": ["music-metadata@11.12.1", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.4.3", "file-type": "^21.3.0", "media-typer": "^1.1.0", "strtok3": "^10.3.4", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-j++ltLxHDb5VCXET9FzQ8bnueiLHwQKgCO7vcbkRH/3F7fRjPkv6qncGEJ47yFhmemcYtgvsOAlcQ1dRBTkDjg=="],
+    "music-metadata": ["music-metadata@11.12.3", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.4.3", "file-type": "^21.3.1", "media-typer": "^1.1.0", "strtok3": "^10.3.4", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ=="],
 
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
-
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
-
-    "node-addon-api": ["node-addon-api@8.6.0", "", {}, "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q=="],
-
-    "node-api-headers": ["node-api-headers@1.8.0", "", {}, "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-edge-tts": ["node-edge-tts@1.2.10", "", { "dependencies": { "https-proxy-agent": "^7.0.1", "ws": "^8.13.0", "yargs": "^17.7.2" }, "bin": { "node-edge-tts": "bin.js" } }, "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
-    "node-llama-cpp": ["node-llama-cpp@3.16.2", "", { "dependencies": { "@huggingface/jinja": "^0.5.5", "async-retry": "^1.3.3", "bytes": "^3.1.2", "chalk": "^5.6.2", "chmodrp": "^1.0.2", "cmake-js": "^8.0.0", "cross-spawn": "^7.0.6", "env-var": "^7.5.0", "filenamify": "^6.0.0", "fs-extra": "^11.3.0", "ignore": "^7.0.4", "ipull": "^3.9.5", "is-unicode-supported": "^2.1.0", "lifecycle-utils": "^3.1.1", "log-symbols": "^7.0.1", "nanoid": "^5.1.6", "node-addon-api": "^8.5.0", "octokit": "^5.0.5", "ora": "^9.3.0", "pretty-ms": "^9.3.0", "proper-lockfile": "^4.1.2", "semver": "^7.7.1", "simple-git": "^3.31.1", "slice-ansi": "^8.0.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.1.2", "validate-npm-package-name": "^7.0.2", "which": "^6.0.1", "yargs": "^17.7.2" }, "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.16.2", "@node-llama-cpp/linux-armv7l": "3.16.2", "@node-llama-cpp/linux-x64": "3.16.2", "@node-llama-cpp/linux-x64-cuda": "3.16.2", "@node-llama-cpp/linux-x64-cuda-ext": "3.16.2", "@node-llama-cpp/linux-x64-vulkan": "3.16.2", "@node-llama-cpp/mac-arm64-metal": "3.16.2", "@node-llama-cpp/mac-x64": "3.16.2", "@node-llama-cpp/win-arm64": "3.16.2", "@node-llama-cpp/win-x64": "3.16.2", "@node-llama-cpp/win-x64-cuda": "3.16.2", "@node-llama-cpp/win-x64-cuda-ext": "3.16.2", "@node-llama-cpp/win-x64-vulkan": "3.16.2" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"], "bin": { "nlc": "dist/cli/cli.js", "node-llama-cpp": "dist/cli/cli.js" } }, "sha512-ovhuTaXSWfcoyfI8ljWxO2Rg63mNxqQQAbDGkXRhlgsL7UjPqm2Nsy1bTNa0ZaQRg3vezG4agnCJTImrICY/0A=="],
 
     "node-readable-to-web-readable-stream": ["node-readable-to-web-readable-stream@0.4.2", "", {}, "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ=="],
 
@@ -1203,23 +1041,17 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "octokit": ["octokit@5.0.5", "", { "dependencies": { "@octokit/app": "^16.1.2", "@octokit/core": "^7.0.6", "@octokit/oauth-app": "^8.0.3", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.0.0" } }, "sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw=="],
-
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
-
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
-    "openclaw": ["openclaw@2026.3.8", "", { "dependencies": { "@agentclientprotocol/sdk": "0.15.0", "@aws-sdk/client-bedrock": "^3.1004.0", "@buape/carbon": "0.0.0-beta-20260216184201", "@clack/prompts": "^1.1.0", "@discordjs/voice": "^0.19.0", "@grammyjs/runner": "^2.0.3", "@grammyjs/transformer-throttler": "^1.2.1", "@homebridge/ciao": "^1.3.5", "@larksuiteoapi/node-sdk": "^1.59.0", "@line/bot-sdk": "^10.6.0", "@lydell/node-pty": "1.2.0-beta.3", "@mariozechner/pi-agent-core": "0.57.1", "@mariozechner/pi-ai": "0.57.1", "@mariozechner/pi-coding-agent": "0.57.1", "@mariozechner/pi-tui": "0.57.1", "@mozilla/readability": "^0.6.0", "@sinclair/typebox": "0.34.48", "@slack/bolt": "^4.6.0", "@slack/web-api": "^7.14.1", "@whiskeysockets/baileys": "7.0.0-rc.9", "ajv": "^8.18.0", "chalk": "^5.6.2", "chokidar": "^5.0.0", "cli-highlight": "^2.1.11", "commander": "^14.0.3", "croner": "^10.0.1", "discord-api-types": "^0.38.41", "dotenv": "^17.3.1", "express": "^5.2.1", "file-type": "^21.3.0", "grammy": "^1.41.1", "https-proxy-agent": "^7.0.6", "ipaddr.js": "^2.3.0", "jiti": "^2.6.1", "json5": "^2.2.3", "jszip": "^3.10.1", "linkedom": "^0.18.12", "long": "^5.3.2", "markdown-it": "^14.1.1", "node-edge-tts": "^1.2.10", "opusscript": "^0.1.1", "osc-progress": "^0.3.0", "pdfjs-dist": "^5.5.207", "playwright-core": "1.58.2", "qrcode-terminal": "^0.12.0", "sharp": "^0.34.5", "sqlite-vec": "0.1.7-alpha.2", "tar": "7.5.11", "tslog": "^4.10.2", "undici": "^7.22.0", "ws": "^8.19.0", "yaml": "^2.8.2", "zod": "^4.3.6" }, "peerDependencies": { "@napi-rs/canvas": "^0.1.89", "node-llama-cpp": "3.16.2" }, "bin": { "openclaw": "openclaw.mjs" } }, "sha512-e5Rk2Aj55sD/5LyX94mdYCQj7zpHXo0xIZsl+k140+nRopePfPAxC7nsu0V/NyypPRtaotP1riFfzK7IhaYkuQ=="],
+    "openclaw": ["openclaw@2026.3.13", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@aws-sdk/client-bedrock": "^3.1009.0", "@buape/carbon": "0.0.0-beta-20260216184201", "@clack/prompts": "^1.1.0", "@discordjs/voice": "^0.19.1", "@grammyjs/runner": "^2.0.3", "@grammyjs/transformer-throttler": "^1.2.1", "@homebridge/ciao": "^1.3.5", "@larksuiteoapi/node-sdk": "^1.59.0", "@line/bot-sdk": "^10.6.0", "@lydell/node-pty": "1.2.0-beta.3", "@mariozechner/pi-agent-core": "0.58.0", "@mariozechner/pi-ai": "0.58.0", "@mariozechner/pi-coding-agent": "0.58.0", "@mariozechner/pi-tui": "0.58.0", "@modelcontextprotocol/sdk": "1.27.1", "@mozilla/readability": "^0.6.0", "@sinclair/typebox": "0.34.48", "@slack/bolt": "^4.6.0", "@slack/web-api": "^7.15.0", "@whiskeysockets/baileys": "7.0.0-rc.9", "ajv": "^8.18.0", "chalk": "^5.6.2", "chokidar": "^5.0.0", "cli-highlight": "^2.1.11", "commander": "^14.0.3", "croner": "^10.0.1", "discord-api-types": "^0.38.42", "dotenv": "^17.3.1", "express": "^5.2.1", "file-type": "^21.3.2", "grammy": "^1.41.1", "hono": "4.12.7", "https-proxy-agent": "^8.0.0", "ipaddr.js": "^2.3.0", "jiti": "^2.6.1", "json5": "^2.2.3", "jszip": "^3.10.1", "linkedom": "^0.18.12", "long": "^5.3.2", "markdown-it": "^14.1.1", "node-edge-tts": "^1.2.10", "opusscript": "^0.1.1", "osc-progress": "^0.3.0", "pdfjs-dist": "^5.5.207", "playwright-core": "1.58.2", "qrcode-terminal": "^0.12.0", "sharp": "^0.34.5", "sqlite-vec": "0.1.7-alpha.2", "tar": "7.5.11", "tslog": "^4.10.2", "undici": "^7.24.1", "ws": "^8.19.0", "yaml": "^2.8.2", "zod": "^4.3.6" }, "peerDependencies": { "@napi-rs/canvas": "^0.1.89", "node-llama-cpp": "3.16.2" }, "optionalPeers": ["node-llama-cpp"], "bin": { "openclaw": "openclaw.mjs" } }, "sha512-/juSUb070Xz8K8CnShjaZQr7CVtRaW4FbR93lgr1hLepcRSbyz2PQR+V4w5giVWkea61opXWPA6Vb8dybaztFg=="],
 
     "opusscript": ["opusscript@0.1.1", "", {}, "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA=="],
-
-    "ora": ["ora@9.3.0", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.1", "string-width": "^8.1.0" } }, "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw=="],
 
     "osc-progress": ["osc-progress@0.3.0", "", {}, "sha512-4/8JfsetakdeEa4vAYV45FW20aY+B/+K8NEXp5Eiar3wR8726whgHrbSg5Ar/ZY1FLJ/AGtUqV7W2IVF+Gvp9A=="],
 
@@ -1235,11 +1067,7 @@
 
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
-    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
-
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
-
-    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
@@ -1249,7 +1077,7 @@
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
-    "path-expression-matcher": ["path-expression-matcher@1.1.2", "", {}, "sha512-LXWqJmcpp2BKOEmgt4CyuESFmBfPuhJlAHKJsFzuJU6CxErWk75BrO+Ni77M9OxHN6dCYKM4vj+21Z6cOL96YQ=="],
+    "path-expression-matcher": ["path-expression-matcher@1.1.3", "", {}, "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1267,11 +1095,9 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
-
-    "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
-
-    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
     "prism-media": ["prism-media@1.3.5", "", { "peerDependencies": { "@discordjs/opus": ">=0.8.0 <1.0.0", "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0", "node-opus": "^0.3.3", "opusscript": "^0.0.8" }, "optionalPeers": ["@discordjs/opus", "ffmpeg-static", "node-opus", "opusscript"] }, "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA=="],
 
@@ -1305,8 +1131,6 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
-
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
@@ -1317,11 +1141,7 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
-
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
-
-    "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -1357,15 +1177,9 @@
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "simple-git": ["simple-git@3.33.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "debug": "^4.4.0" } }, "sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng=="],
-
     "simple-wcswidth": ["simple-wcswidth@1.1.2", "", {}, "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
-
-    "sleep-promise": ["sleep-promise@9.1.0", "", {}, "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA=="],
-
-    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
@@ -1397,23 +1211,11 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "stdin-discarder": ["stdin-discarder@0.3.1", "", {}, "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA=="],
-
-    "stdout-update": ["stdout-update@4.0.1", "", { "dependencies": { "ansi-escapes": "^6.2.0", "ansi-styles": "^6.2.1", "string-width": "^7.1.0", "strip-ansi": "^7.1.0" } }, "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ=="],
-
-    "steno": ["steno@4.0.2", "", {}, "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A=="],
-
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "strnum": ["strnum@2.2.0", "", {}, "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg=="],
 
@@ -1428,8 +1230,6 @@
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
-
-    "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
@@ -1459,25 +1259,15 @@
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
-    "undici": ["undici@7.22.0", "", {}, "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="],
+    "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "universal-github-app-jwt": ["universal-github-app-jwt@2.2.2", "", {}, "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="],
-
-    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
-
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
-    "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
-
-    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -1487,13 +1277,11 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -1521,19 +1309,15 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1005.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.19", "@aws-sdk/nested-clients": "^3.996.8", "@aws-sdk/types": "^3.973.5", "@smithy/property-provider": "^4.2.11", "@smithy/shared-ini-file-loader": "^4.4.6", "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-vMxd+ivKqSxU9bHx5vmAlFKDAkjGotFU56IOkDa5DaTu1WWwbcse0yFHEm9I537oVvodaiwMl3VBwgHfzQ2rvw=="],
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1009.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.20", "@aws-sdk/nested-clients": "^3.996.10", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA=="],
 
     "@buape/carbon/@discordjs/voice": ["@discordjs/voice@0.19.0", "", { "dependencies": { "@types/ws": "^8.18.1", "discord-api-types": "^0.38.16", "prism-media": "^1.3.5", "tslib": "^2.8.1", "ws": "^8.18.3" } }, "sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw=="],
 
     "@buape/carbon/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
-    "@buape/carbon/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@buape/carbon/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@buape/carbon/discord-api-types": ["discord-api-types@0.38.37", "", {}, "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w=="],
-
-    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@langchain/langgraph/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
@@ -1551,37 +1335,39 @@
 
     "@mariozechner/pi-coding-agent/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
+    "@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
     "@prefactor/cli/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@prefactor/openclaw/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
-    "@slack/logger/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@slack/logger/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@slack/oauth/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@slack/oauth/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@slack/socket-mode/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@slack/socket-mode/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@slack/socket-mode/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
-    "@slack/web-api/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
+    "@slack/web-api/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@slack/web-api/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
-    "@types/body-parser/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/body-parser/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@types/connect/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/connect/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@types/express-serve-static-core/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/express-serve-static-core/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@types/jsonwebtoken/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/jsonwebtoken/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@types/send/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/send/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@types/serve-static/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/serve-static/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@types/ws/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/ws/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@types/yauzl/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/yauzl/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@whiskeysockets/baileys/p-queue": ["p-queue@9.1.0", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw=="],
 
@@ -1591,13 +1377,9 @@
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "cmake-js/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
-
-    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
-    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -1605,65 +1387,41 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "ipull/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
-
-    "ipull/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
-
-    "ipull/lifecycle-utils": ["lifecycle-utils@2.1.0", "", {}, "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA=="],
-
-    "ipull/pretty-ms": ["pretty-ms@8.0.0", "", { "dependencies": { "parse-ms": "^3.0.0" } }, "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q=="],
-
-    "ipull/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+    "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "langsmith/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "libsignal/protobufjs": ["protobufjs@6.8.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.0", "@types/node": "^10.1.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw=="],
 
+    "node-edge-tts/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "node-edge-tts/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
-    "node-llama-cpp/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+    "pac-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ora/cli-spinners": ["cli-spinners@3.4.0", "", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
-
-    "ora/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
+    "pac-proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
-    "protobufjs/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "protobufjs/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
-    "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
-    "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "stdout-update/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "stdout-update/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "socks-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -1674,10 +1432,6 @@
     "@buape/carbon/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "@buape/carbon/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@langchain/langgraph-sdk/p-queue/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
@@ -1694,6 +1448,8 @@
     "@slack/oauth/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@slack/socket-mode/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@slack/web-api/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@types/body-parser/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -1719,45 +1475,25 @@
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "cmake-js/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "cmake-js/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "gaxios/node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
-    "ipull/pretty-ms/parse-ms": ["parse-ms@3.0.0", "", {}, "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="],
-
-    "ipull/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
     "libsignal/protobufjs/@types/node": ["@types/node@10.17.60", "", {}, "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="],
 
     "libsignal/protobufjs/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
+
+    "node-edge-tts/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "node-edge-tts/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "node-edge-tts/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "node-llama-cpp/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "node-llama-cpp/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "protobufjs/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "stdout-update/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -1771,20 +1507,10 @@
 
     "@prefactor/cli/@types/bun/bun-types/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
-    "cmake-js/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "node-edge-tts/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "node-llama-cpp/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "cmake-js/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "node-edge-tts/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "node-llama-cpp/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/examples/ai-sdk/custom-schema.ts
+++ b/examples/ai-sdk/custom-schema.ts
@@ -12,7 +12,7 @@
 import { anthropic } from '@ai-sdk/anthropic';
 import { generateText, stepCountIs, tool, wrapLanguageModel } from 'ai';
 import { init } from '@prefactor/core';
-import { PrefactorAISDK, type LanguageModelMiddleware } from '@prefactor/ai';
+import { PrefactorAISDK } from '@prefactor/ai';
 import { z } from 'zod';
 
 const customSchema = {
@@ -145,23 +145,22 @@ async function main() {
   console.log('='.repeat(80));
   console.log();
 
-  let prefactor: ReturnType<typeof init> | undefined;
-  try {
-    prefactor = init({
-      provider: new PrefactorAISDK(),
-      httpConfig: {
-        apiUrl: PREFACTOR_API_URL,
-        apiToken: PREFACTOR_API_TOKEN,
-        agentId: PREFACTOR_AGENT_ID,
-        agentIdentifier: '1.0.0-schema',
-        agentName: 'AI SDK Custom Schema Demo',
-        agentSchema: customSchema,
-      },
-    });
+  const prefactor = init({
+    provider: new PrefactorAISDK(),
+    httpConfig: {
+      apiUrl: PREFACTOR_API_URL,
+      apiToken: PREFACTOR_API_TOKEN,
+      agentId: PREFACTOR_AGENT_ID,
+      agentIdentifier: '1.0.0-schema',
+      agentName: 'AI SDK Custom Schema Demo',
+      agentSchema: customSchema,
+    },
+  });
 
+  try {
     const model = wrapLanguageModel({
       model: anthropic('claude-3-haiku-20240307'),
-      middleware: prefactor.getMiddleware() as LanguageModelMiddleware,
+      middleware: prefactor.getMiddleware(),
     });
 
     const getTodayDateTool = tool({

--- a/examples/ai-sdk/simple-agent.ts
+++ b/examples/ai-sdk/simple-agent.ts
@@ -11,7 +11,7 @@
  */
 
 import { init } from '@prefactor/core';
-import { PrefactorAISDK, type LanguageModelMiddleware } from '@prefactor/ai';
+import { PrefactorAISDK } from '@prefactor/ai';
 import { generateText, wrapLanguageModel, tool, stepCountIs } from 'ai';
 import { anthropic } from '@ai-sdk/anthropic';
 import { z } from 'zod';
@@ -144,7 +144,7 @@ async function main() {
   // This is the key difference from the experimental_telemetry approach
   const model = wrapLanguageModel({
     model: anthropic('claude-3-haiku-20240307'),
-    middleware: prefactor.getMiddleware() as LanguageModelMiddleware,
+    middleware: prefactor.getMiddleware(),
   });
 
   console.log('Model wrapped with Prefactor middleware');

--- a/examples/tool-schema/simple-agent.ts
+++ b/examples/tool-schema/simple-agent.ts
@@ -1,35 +1,32 @@
-import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, stepCountIs, tool, wrapLanguageModel } from 'ai';
-import { init } from '@prefactor/core';
-import { PrefactorAISDK } from '@prefactor/ai';
-import { z } from 'zod';
-
-const PREFACTOR_API_URL = 'https://app.prefactorai.com';
-const PREFACTOR_AGENT_ID = '01kkd1xbgaesddxmzgzzgxb642d13ej7';
-const PREFACTOR_AGENT_IDENTIFIER = 'tool-schema-example-v4';
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateText, stepCountIs, tool, wrapLanguageModel } from "ai";
+import { init } from "@prefactor/core";
+import { PrefactorAISDK } from "@prefactor/ai";
+import { z } from "zod";
+const PREFACTOR_AGENT_IDENTIFIER = "tool-schema-example-v4";
 
 const customerProfileInputSchema = z.object({
-  customerId: z.string().describe('Customer identifier to retrieve'),
+  customerId: z.string().describe("Customer identifier to retrieve"),
 });
 
 const sendEmailInputSchema = z.object({
-  to: z.email().describe('Recipient email address'),
-  subject: z.string().describe('Email subject'),
-  body: z.string().describe('Email body text'),
+  to: z.email().describe("Recipient email address"),
+  subject: z.string().describe("Email subject"),
+  body: z.string().describe("Email body text"),
 });
 
 const getCustomerProfileTool = tool({
-  description: 'Fetch a synthetic customer profile for a given customer ID.',
+  description: "Fetch a synthetic customer profile for a given customer ID.",
   inputSchema: customerProfileInputSchema,
   execute: async ({ customerId }) => ({
     id: customerId,
     email: `${customerId}@example.com`,
-    name: 'Taylor Example',
+    name: "Taylor Example",
   }),
 });
 
 const sendEmailTool = tool({
-  description: 'Pretend to send an email and return a delivery receipt.',
+  description: "Pretend to send an email and return a delivery receipt.",
   inputSchema: sendEmailInputSchema,
   execute: async ({ to, subject }) => ({
     receiptId: `receipt-${to}-${subject.length}`,
@@ -38,7 +35,7 @@ const sendEmailTool = tool({
 });
 
 const getCurrentDateTool = tool({
-  description: 'Return today in YYYY-MM-DD format.',
+  description: "Return today in YYYY-MM-DD format.",
   inputSchema: z.object({}),
   execute: async () => new Date().toISOString().slice(0, 10),
 });
@@ -47,47 +44,51 @@ async function main() {
   const { ANTHROPIC_API_KEY, PREFACTOR_API_TOKEN } = process.env;
 
   if (!ANTHROPIC_API_KEY) {
-    throw new Error('ANTHROPIC_API_KEY must be set before running this example.');
+    throw new Error(
+      "ANTHROPIC_API_KEY must be set before running this example.",
+    );
   }
 
   if (!PREFACTOR_API_TOKEN) {
-    throw new Error('PREFACTOR_API_TOKEN must be set before running this example.');
+    throw new Error(
+      "PREFACTOR_API_TOKEN must be set before running this example.",
+    );
   }
 
   const prefactor = init({
     provider: new PrefactorAISDK(),
     httpConfig: {
-      apiUrl: PREFACTOR_API_URL,
+      apiUrl: process.env.PREFACTOR_API_URL!,
       apiToken: PREFACTOR_API_TOKEN,
-      agentId: PREFACTOR_AGENT_ID,
+      agentId: process.env.PREFACTOR_AGENT_ID,
       agentIdentifier: PREFACTOR_AGENT_IDENTIFIER,
-      agentName: 'Tool Schema Example',
-      agentDescription: 'AI SDK example for automatic per-tool span schemas.',
+      agentName: "Tool Schema Example",
+      agentDescription: "AI SDK example for automatic per-tool span schemas.",
       agentSchema: {
-        external_identifier: 'ai-sdk-tool-schema-example-v3',
+        external_identifier: "ai-sdk-tool-schema-example-v3",
         span_schemas: {},
         span_result_schemas: {},
         toolSchemas: {
           get_customer_profile: {
-            spanType: 'get-customer-profile',
+            spanType: "get-customer-profile",
             inputSchema: {
-              type: 'object',
+              type: "object",
               properties: {
-                customerId: { type: 'string' },
+                customerId: { type: "string" },
               },
-              required: ['customerId'],
+              required: ["customerId"],
             },
           },
           send_email: {
-            spanType: 'send-email',
+            spanType: "send-email",
             inputSchema: {
-              type: 'object',
+              type: "object",
               properties: {
-                to: { type: 'string', format: 'email' },
-                subject: { type: 'string' },
-                body: { type: 'string' },
+                to: { type: "string", format: "email" },
+                subject: { type: "string" },
+                body: { type: "string" },
               },
-              required: ['to', 'subject', 'body'],
+              required: ["to", "subject", "body"],
             },
           },
         },
@@ -96,7 +97,7 @@ async function main() {
   });
 
   const model = wrapLanguageModel({
-    model: anthropic('claude-3-haiku-20240307'),
+    model: anthropic("claude-3-haiku-20240307"),
     middleware: prefactor.getMiddleware(),
   });
 
@@ -104,7 +105,7 @@ async function main() {
     const result = await generateText({
       model,
       prompt:
-        'Use get_customer_profile for customer cust_123, then use send_email to notify them that their profile review is complete. Also use get_current_date. After the tool calls, return a final plain-text summary that includes the customer email, whether the email send was accepted, and today\'s date.',
+        "Use get_customer_profile for customer cust_123, then use send_email to notify them that their profile review is complete. Also use get_current_date. After the tool calls, return a final plain-text summary that includes the customer email, whether the email send was accepted, and today's date.",
       tools: {
         get_customer_profile: getCustomerProfileTool,
         send_email: sendEmailTool,
@@ -113,19 +114,21 @@ async function main() {
       stopWhen: stepCountIs(6),
     });
 
-    console.log('Agent identifier:', PREFACTOR_AGENT_IDENTIFIER);
-    console.log('Schema identifier:', 'ai-sdk-tool-schema-example-v3');
-    console.log('Response:');
-    console.log(result.text || '(model returned no final text)');
+    console.log("Agent identifier:", PREFACTOR_AGENT_IDENTIFIER);
+    console.log("Schema identifier:", "ai-sdk-tool-schema-example-v3");
+    console.log("Response:");
+    console.log(result.text || "(model returned no final text)");
     console.log();
-    console.log('Tool calls:');
+    console.log("Tool calls:");
     for (const toolCall of result.toolCalls) {
       console.log(`- ${toolCall.toolName}: ${JSON.stringify(toolCall.input)}`);
     }
     console.log();
-    console.log('Tool results:');
+    console.log("Tool results:");
     for (const toolResult of result.toolResults ?? []) {
-      console.log(`- ${toolResult.toolName}: ${JSON.stringify(toolResult.output)}`);
+      console.log(
+        `- ${toolResult.toolName}: ${JSON.stringify(toolResult.output)}`,
+      );
     }
   } finally {
     await prefactor.shutdown();

--- a/examples/tool-schema/simple-agent.ts
+++ b/examples/tool-schema/simple-agent.ts
@@ -1,0 +1,138 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, stepCountIs, tool, wrapLanguageModel } from 'ai';
+import { init } from '@prefactor/core';
+import { PrefactorAISDK } from '@prefactor/ai';
+import { z } from 'zod';
+
+const PREFACTOR_API_URL = 'https://app.prefactorai.com';
+const PREFACTOR_AGENT_ID = '01kkd1xbgaesddxmzgzzgxb642d13ej7';
+const PREFACTOR_AGENT_IDENTIFIER = 'tool-schema-example-v4';
+
+const customerProfileInputSchema = z.object({
+  customerId: z.string().describe('Customer identifier to retrieve'),
+});
+
+const sendEmailInputSchema = z.object({
+  to: z.email().describe('Recipient email address'),
+  subject: z.string().describe('Email subject'),
+  body: z.string().describe('Email body text'),
+});
+
+const getCustomerProfileTool = tool({
+  description: 'Fetch a synthetic customer profile for a given customer ID.',
+  inputSchema: customerProfileInputSchema,
+  execute: async ({ customerId }) => ({
+    id: customerId,
+    email: `${customerId}@example.com`,
+    name: 'Taylor Example',
+  }),
+});
+
+const sendEmailTool = tool({
+  description: 'Pretend to send an email and return a delivery receipt.',
+  inputSchema: sendEmailInputSchema,
+  execute: async ({ to, subject }) => ({
+    receiptId: `receipt-${to}-${subject.length}`,
+    accepted: true,
+  }),
+});
+
+const getCurrentDateTool = tool({
+  description: 'Return today in YYYY-MM-DD format.',
+  inputSchema: z.object({}),
+  execute: async () => new Date().toISOString().slice(0, 10),
+});
+
+async function main() {
+  const { ANTHROPIC_API_KEY, PREFACTOR_API_TOKEN } = process.env;
+
+  if (!ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY must be set before running this example.');
+  }
+
+  if (!PREFACTOR_API_TOKEN) {
+    throw new Error('PREFACTOR_API_TOKEN must be set before running this example.');
+  }
+
+  const prefactor = init({
+    provider: new PrefactorAISDK(),
+    httpConfig: {
+      apiUrl: PREFACTOR_API_URL,
+      apiToken: PREFACTOR_API_TOKEN,
+      agentId: PREFACTOR_AGENT_ID,
+      agentIdentifier: PREFACTOR_AGENT_IDENTIFIER,
+      agentName: 'Tool Schema Example',
+      agentDescription: 'AI SDK example for automatic per-tool span schemas.',
+      agentSchema: {
+        external_identifier: 'ai-sdk-tool-schema-example-v3',
+        span_schemas: {},
+        span_result_schemas: {},
+        toolSchemas: {
+          get_customer_profile: {
+            spanType: 'get-customer-profile',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                customerId: { type: 'string' },
+              },
+              required: ['customerId'],
+            },
+          },
+          send_email: {
+            spanType: 'send-email',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                to: { type: 'string', format: 'email' },
+                subject: { type: 'string' },
+                body: { type: 'string' },
+              },
+              required: ['to', 'subject', 'body'],
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const model = wrapLanguageModel({
+    model: anthropic('claude-3-haiku-20240307'),
+    middleware: prefactor.getMiddleware(),
+  });
+
+  try {
+    const result = await generateText({
+      model,
+      prompt:
+        'Use get_customer_profile for customer cust_123, then use send_email to notify them that their profile review is complete. Also use get_current_date. After the tool calls, return a final plain-text summary that includes the customer email, whether the email send was accepted, and today\'s date.',
+      tools: {
+        get_customer_profile: getCustomerProfileTool,
+        send_email: sendEmailTool,
+        get_current_date: getCurrentDateTool,
+      },
+      stopWhen: stepCountIs(6),
+    });
+
+    console.log('Agent identifier:', PREFACTOR_AGENT_IDENTIFIER);
+    console.log('Schema identifier:', 'ai-sdk-tool-schema-example-v3');
+    console.log('Response:');
+    console.log(result.text || '(model returned no final text)');
+    console.log();
+    console.log('Tool calls:');
+    for (const toolCall of result.toolCalls) {
+      console.log(`- ${toolCall.toolName}: ${JSON.stringify(toolCall.input)}`);
+    }
+    console.log();
+    console.log('Tool results:');
+    for (const toolResult of result.toolResults ?? []) {
+      console.log(`- ${toolResult.toolName}: ${JSON.stringify(toolResult.output)}`);
+    }
+  } finally {
+    await prefactor.shutdown();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prefactor/ai",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Vercel AI SDK middleware integration for Prefactor observability",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -43,13 +43,12 @@
  * @packageDocumentation
  */
 
+export type { ManualSpanOptions } from './init.js';
 // Initialization
 export { getTracer, init, shutdown, withSpan } from './init.js';
-export type { ManualSpanOptions } from './init.js';
-
+export type { PrefactorAISDKOptions } from './provider.js';
 // Provider
 export { DEFAULT_AI_AGENT_SCHEMA, PrefactorAISDK } from './provider.js';
-export type { PrefactorAISDKOptions } from './provider.js';
 
 // Types
 export type {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -43,8 +43,18 @@
  * @packageDocumentation
  */
 
+// Initialization
+export { getTracer, init, shutdown, withSpan } from './init.js';
+export type { ManualSpanOptions } from './init.js';
+
 // Provider
 export { DEFAULT_AI_AGENT_SCHEMA, PrefactorAISDK } from './provider.js';
+export type { PrefactorAISDKOptions } from './provider.js';
 
 // Types
-export type { LanguageModelMiddleware, MiddlewareConfig } from './types.js';
+export type {
+  JsonSchema,
+  LanguageModelMiddleware,
+  MiddlewareConfig,
+  ToolSchemaConfig,
+} from './types.js';

--- a/packages/ai/src/init.ts
+++ b/packages/ai/src/init.ts
@@ -132,6 +132,10 @@ export function init(
   config?: Partial<Config>,
   middlewareConfig?: MiddlewareConfig
 ): ReturnType<typeof createPrefactorMiddleware> {
+  if (globalMiddleware !== null) {
+    return globalMiddleware;
+  }
+
   configureLogging();
   const preparedConfig = applyDefaultHttpConfig(config);
   const { config: finalConfig, toolSpanTypes } = normalizeConfiguredAgentSchema(
@@ -139,11 +143,6 @@ export function init(
   );
 
   logger.info('Initializing Prefactor AI Middleware', { transport: finalConfig.transportType });
-
-  // Return existing middleware if already initialized
-  if (globalMiddleware !== null) {
-    return globalMiddleware;
-  }
 
   const core = createCore(finalConfig);
   globalCore = core;

--- a/packages/ai/src/init.ts
+++ b/packages/ai/src/init.ts
@@ -21,23 +21,10 @@ import {
   withSpan as withCoreSpan,
 } from '@prefactor/core';
 import { createPrefactorMiddleware } from './middleware.js';
+import { DEFAULT_AI_AGENT_SCHEMA, normalizeAgentSchema } from './schema.js';
 import type { MiddlewareConfig } from './types.js';
 
 const logger = getLogger('ai-init');
-
-const DEFAULT_AI_AGENT_SCHEMA = {
-  external_identifier: 'ai-sdk-schema',
-  span_schemas: {
-    'ai-sdk:agent': { type: 'object', additionalProperties: true },
-    'ai-sdk:llm': { type: 'object', additionalProperties: true },
-    'ai-sdk:tool': { type: 'object', additionalProperties: true },
-  },
-  span_result_schemas: {
-    'ai-sdk:agent': { type: 'object', additionalProperties: true },
-    'ai-sdk:llm': { type: 'object', additionalProperties: true },
-    'ai-sdk:tool': { type: 'object', additionalProperties: true },
-  },
-} as const;
 
 /** Global Prefactor tracer instance. */
 let globalTracer: Tracer | null = null;
@@ -146,45 +133,11 @@ export function init(
   middlewareConfig?: MiddlewareConfig
 ): ReturnType<typeof createPrefactorMiddleware> {
   configureLogging();
+  const preparedConfig = applyDefaultHttpConfig(config);
+  const { config: finalConfig, toolSpanTypes } = normalizeConfiguredAgentSchema(
+    createConfig(preparedConfig)
+  );
 
-  // Build httpConfig from environment if not provided but HTTP transport is requested
-  let configWithHttp = config;
-  const transportType = config?.transportType ?? 'http';
-
-  if (transportType === 'http' && !config?.httpConfig) {
-    const apiUrl = process.env.PREFACTOR_API_URL;
-    const apiToken = process.env.PREFACTOR_API_TOKEN;
-
-    if (!apiUrl || !apiToken) {
-      throw new Error(
-        'HTTP transport requires PREFACTOR_API_URL and PREFACTOR_API_TOKEN environment variables, ' +
-          'or httpConfig to be provided in configuration'
-      );
-    }
-
-    configWithHttp = {
-      ...config,
-      transportType: 'http',
-      httpConfig: {
-        apiUrl,
-        apiToken,
-        agentId: process.env.PREFACTOR_AGENT_ID,
-        agentName: process.env.PREFACTOR_AGENT_NAME,
-        agentIdentifier: process.env.PREFACTOR_AGENT_IDENTIFIER || '1.0.0',
-        agentSchema: DEFAULT_AI_AGENT_SCHEMA,
-      },
-    };
-  } else if (transportType === 'http' && config?.httpConfig && !config.httpConfig.agentSchema) {
-    configWithHttp = {
-      ...config,
-      httpConfig: {
-        ...config.httpConfig,
-        agentSchema: DEFAULT_AI_AGENT_SCHEMA,
-      },
-    };
-  }
-
-  const finalConfig = createConfig(configWithHttp);
   logger.info('Initializing Prefactor AI Middleware', { transport: finalConfig.transportType });
 
   // Return existing middleware if already initialized
@@ -216,6 +169,7 @@ export function init(
     agentInfo,
     agentManager: core.agentManager,
     agentLifecycle,
+    toolSpanTypes,
   });
 
   return globalMiddleware;
@@ -255,10 +209,7 @@ export function getTracer(): Tracer {
  * @param fn - Function to execute in span context.
  * @returns Result from `fn`.
  */
-export async function withSpan<T>(
-  options: ManualSpanOptions,
-  fn: () => Promise<T> | T
-): Promise<T> {
+export function withSpan<T>(options: ManualSpanOptions, fn: () => Promise<T> | T): Promise<T> {
   return withCoreSpan(options, fn);
 }
 
@@ -267,6 +218,75 @@ export { shutdownCore as shutdown };
 // Automatic shutdown on process exit
 process.on('beforeExit', () => {
   shutdownCore().catch((error) => {
-    console.error('Error during Prefactor AI Middleware shutdown:', error);
+    logger.error('Error during Prefactor AI Middleware shutdown:', error);
   });
 });
+
+function applyDefaultHttpConfig(config?: Partial<Config>): Partial<Config> | undefined {
+  const transportType = config?.transportType ?? 'http';
+  if (transportType !== 'http') {
+    return config;
+  }
+
+  if (!config?.httpConfig) {
+    return buildHttpConfigFromEnvironment(config);
+  }
+
+  if (config.httpConfig.agentSchema) {
+    return config;
+  }
+
+  return {
+    ...config,
+    httpConfig: {
+      ...config.httpConfig,
+      agentSchema: DEFAULT_AI_AGENT_SCHEMA,
+    },
+  };
+}
+
+function buildHttpConfigFromEnvironment(config?: Partial<Config>): Partial<Config> {
+  const apiUrl = process.env.PREFACTOR_API_URL;
+  const apiToken = process.env.PREFACTOR_API_TOKEN;
+
+  if (!apiUrl || !apiToken) {
+    throw new Error(
+      'HTTP transport requires PREFACTOR_API_URL and PREFACTOR_API_TOKEN environment variables, ' +
+        'or httpConfig to be provided in configuration'
+    );
+  }
+
+  return {
+    ...config,
+    transportType: 'http',
+    httpConfig: {
+      apiUrl,
+      apiToken,
+      agentId: process.env.PREFACTOR_AGENT_ID,
+      agentName: process.env.PREFACTOR_AGENT_NAME,
+      agentIdentifier: process.env.PREFACTOR_AGENT_IDENTIFIER || '1.0.0',
+      agentSchema: DEFAULT_AI_AGENT_SCHEMA,
+    },
+  };
+}
+
+function normalizeConfiguredAgentSchema(config: Config): {
+  config: Config;
+  toolSpanTypes?: Record<string, string>;
+} {
+  if (!config.httpConfig?.agentSchema) {
+    return { config };
+  }
+
+  const normalizedSchema = normalizeAgentSchema(config.httpConfig.agentSchema);
+  return {
+    config: {
+      ...config,
+      httpConfig: {
+        ...config.httpConfig,
+        agentSchema: normalizedSchema.agentSchema,
+      },
+    },
+    toolSpanTypes: normalizedSchema.toolSpanTypes,
+  };
+}

--- a/packages/ai/src/middleware.ts
+++ b/packages/ai/src/middleware.ts
@@ -8,26 +8,54 @@
  * @packageDocumentation
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   type AgentInstanceManager,
-  createSpanTypePrefixer,
   type Span,
   SpanContext,
   SpanType,
   type TokenUsage,
   type Tracer,
 } from '@prefactor/core';
+import { resolveToolSpanType } from './schema.js';
+import { createToolSpanInputs, createToolSpanOutputs } from './tool-span-contract.js';
 import type { LanguageModelMiddleware, MiddlewareConfig } from './types.js';
 
 const AGENT_DEAD_TIMEOUT_MS = 5 * 60 * 1000;
-const toAiSpanType = createSpanTypePrefixer('ai-sdk');
 const WRAPPED_TOOL_EXECUTE = Symbol('prefactor-ai-wrapped-tool-execute');
+const TOOL_CAPTURE_STATE_STORAGE = new AsyncLocalStorage<ToolCaptureState>();
 
 type PromptToolResult = {
   toolName: string;
   toolCallId?: string;
   input?: unknown;
   output: unknown;
+};
+
+type ToolCaptureState = {
+  executedToolNames: Set<string>;
+  executedToolCallIds: Set<string>;
+};
+
+type ToolExecute = (this: unknown, ...args: unknown[]) => unknown;
+type WrappedToolExecute = ToolExecute & { [WRAPPED_TOOL_EXECUTE]?: true };
+type ToolDefinition = {
+  description?: string;
+  execute?: ToolExecute;
+  name?: string;
+};
+type PromptMessage = {
+  content?: unknown;
+  role?: unknown;
+};
+type PromptPart = {
+  args?: unknown;
+  input?: unknown;
+  output?: unknown;
+  text?: unknown;
+  toolCallId?: unknown;
+  toolName?: unknown;
+  type?: unknown;
 };
 
 function toError(error: unknown): Error {
@@ -68,186 +96,221 @@ function markAgentDead(
   agentLifecycle.started = false;
 }
 
+function createToolCaptureState(): ToolCaptureState {
+  return {
+    executedToolNames: new Set<string>(),
+    executedToolCallIds: new Set<string>(),
+  };
+}
+
 function wrapToolExecute(
   tracer: Tracer,
   toolName: string,
-  // biome-ignore lint/suspicious/noExplicitAny: Tool execute signatures vary by provider/version
-  execute: (...args: any[]) => unknown
-  // biome-ignore lint/suspicious/noExplicitAny: Tool execute signatures vary by provider/version
-): (...args: any[]) => Promise<unknown> {
-  // biome-ignore lint/suspicious/noExplicitAny: Symbol metadata on function object
-  if ((execute as any)[WRAPPED_TOOL_EXECUTE]) {
-    return execute as (...args: unknown[]) => Promise<unknown>;
+  toolSpanTypes: Record<string, string> | undefined,
+  execute: ToolExecute
+): WrappedToolExecute {
+  const existingExecute = execute as WrappedToolExecute;
+  if (existingExecute[WRAPPED_TOOL_EXECUTE]) {
+    return existingExecute;
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: Tool execute signatures vary by provider/version
-  const wrapped = async function wrappedExecute(this: unknown, ...args: any[]): Promise<unknown> {
+  const wrapped: WrappedToolExecute = async function wrappedExecute(
+    this: unknown,
+    ...args: unknown[]
+  ): Promise<unknown> {
     const input = args[0] ?? {};
+    const toolCallId = extractToolCallId(args);
     const span = tracer.startSpan({
       name: 'ai:tool-call',
-      spanType: toAiSpanType(SpanType.TOOL),
-      inputs: {
-        'ai.tool.name': toolName,
+      spanType: resolveToolSpanType(toolName, toolSpanTypes),
+      inputs: createToolSpanInputs({
         toolName,
+        toolCallId,
         input,
-      },
+      }),
     });
 
     try {
       const output = await SpanContext.runAsync(span, () =>
         Promise.resolve(execute.apply(this, args))
       );
-      tracer.endSpan(span, { outputs: { output } });
+      const captureState = TOOL_CAPTURE_STATE_STORAGE.getStore();
+      captureState?.executedToolNames.add(toolName);
+      if (toolCallId) {
+        captureState?.executedToolCallIds.add(toolCallId);
+      }
+      tracer.endSpan(span, { outputs: createToolSpanOutputs(output) });
       return output;
     } catch (error) {
       const normalizedError = toError(error);
-      tracer.endSpan(span, { error: normalizedError });
+      tracer.endSpan(span, {
+        outputs: createToolSpanOutputs(undefined),
+        error: normalizedError,
+      });
       throw error;
     }
   };
 
-  // biome-ignore lint/suspicious/noExplicitAny: Symbol metadata on function object
-  (wrapped as any)[WRAPPED_TOOL_EXECUTE] = true;
+  wrapped[WRAPPED_TOOL_EXECUTE] = true;
   return wrapped;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: AI SDK call options are dynamic
-function wrapToolsInParams(params: any, tracer: Tracer): any {
-  if (!params?.tools || typeof params.tools !== 'object') {
+function wrapToolsInParams<T extends Record<string, unknown> & { tools?: unknown }>(
+  params: T,
+  tracer: Tracer,
+  toolSpanTypes?: Record<string, string>
+): T {
+  if (!('tools' in params)) {
     return params;
   }
 
   if (Array.isArray(params.tools)) {
-    params.tools = params.tools.map((tool: unknown, index: number) => {
-      if (!tool || typeof tool !== 'object') {
-        return tool;
-      }
-
-      const typedTool = tool as {
-        name?: string;
-        execute?: (...args: unknown[]) => unknown;
-      };
-
-      if (typeof typedTool.execute !== 'function') {
-        return tool;
-      }
-
-      const toolName = typedTool.name ?? `tool_${index}`;
-      return {
-        ...typedTool,
-        execute: wrapToolExecute(tracer, toolName, typedTool.execute),
-      };
-    });
+    params.tools = wrapToolArray(params.tools, tracer, toolSpanTypes);
     return params;
   }
 
-  const tools = params.tools as Record<string, unknown>;
-  for (const [toolName, tool] of Object.entries(tools)) {
-    if (!tool || typeof tool !== 'object') {
-      continue;
-    }
-
-    const typedTool = tool as {
-      execute?: (...args: unknown[]) => unknown;
-    };
-
-    if (typeof typedTool.execute !== 'function') {
-      continue;
-    }
-
-    tools[toolName] = {
-      ...typedTool,
-      execute: wrapToolExecute(tracer, toolName, typedTool.execute),
-    };
+  if (isRecord(params.tools)) {
+    params.tools = wrapToolMap(params.tools, tracer, toolSpanTypes);
   }
 
   return params;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: AI SDK call options are dynamic
-function hasExecutableToolsInParams(params: any): boolean {
-  if (Array.isArray(params?.tools)) {
-    return params.tools.some(
-      (tool: unknown) =>
-        typeof tool === 'object' &&
-        tool !== null &&
-        typeof (tool as { execute?: unknown }).execute === 'function'
-    );
-  }
+function wrapToolArray(
+  tools: unknown[],
+  tracer: Tracer,
+  toolSpanTypes?: Record<string, string>
+): unknown[] {
+  return tools.map((tool, index) => {
+    const typedTool = getToolDefinition(tool);
+    if (!typedTool?.execute) {
+      return tool;
+    }
 
-  if (params?.tools && typeof params.tools === 'object') {
-    return Object.values(params.tools as Record<string, unknown>).some(
-      (tool: unknown) =>
-        typeof tool === 'object' &&
-        tool !== null &&
-        typeof (tool as { execute?: unknown }).execute === 'function'
-    );
-  }
-
-  return false;
+    const toolName = typedTool.name ?? `tool_${index}`;
+    return {
+      ...typedTool,
+      execute: wrapToolExecute(tracer, toolName, toolSpanTypes, typedTool.execute),
+    };
+  });
 }
 
-function normalizeToolResultOutput(output: unknown): unknown {
-  if (
-    typeof output === 'object' &&
-    output !== null &&
-    (output as { type?: unknown }).type === 'text' &&
-    typeof (output as { value?: unknown }).value === 'string'
-  ) {
-    return (output as { value: string }).value;
+function wrapToolMap(
+  tools: Record<string, unknown>,
+  tracer: Tracer,
+  toolSpanTypes?: Record<string, string>
+): Record<string, unknown> {
+  for (const [toolName, tool] of Object.entries(tools)) {
+    const typedTool = getToolDefinition(tool);
+    if (!typedTool?.execute) {
+      continue;
+    }
+
+    tools[toolName] = {
+      ...typedTool,
+      execute: wrapToolExecute(tracer, toolName, toolSpanTypes, typedTool.execute),
+    };
   }
 
-  return output;
+  return tools;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: AI SDK prompt/message structures are dynamic
-function extractPromptToolResults(params: any): PromptToolResult[] {
-  const prompt = Array.isArray(params?.prompt) ? params.prompt : [];
+function getToolDefinition(tool: unknown): ToolDefinition | undefined {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+
+  return {
+    description: typeof tool.description === 'string' ? tool.description : undefined,
+    execute: typeof tool.execute === 'function' ? (tool.execute as ToolExecute) : undefined,
+    name: typeof tool.name === 'string' ? tool.name : undefined,
+  };
+}
+
+function extractToolCallId(args: unknown[]): string | undefined {
+  for (const arg of args.slice(0, 2)) {
+    if (!arg || typeof arg !== 'object') {
+      continue;
+    }
+
+    const candidate = arg as {
+      toolCallId?: unknown;
+      options?: { toolCallId?: unknown };
+    };
+    if (typeof candidate.toolCallId === 'string') {
+      return candidate.toolCallId;
+    }
+    if (typeof candidate.options?.toolCallId === 'string') {
+      return candidate.options.toolCallId;
+    }
+  }
+
+  return undefined;
+}
+
+function extractPromptToolResults(params: Record<string, unknown>): PromptToolResult[] {
+  const prompt = Array.isArray(params.prompt) ? (params.prompt as PromptMessage[]) : [];
   const toolCallInputs = new Map<string, unknown>();
   const results: PromptToolResult[] = [];
 
   for (const message of prompt) {
-    const content = Array.isArray(message?.content) ? message.content : [];
+    const content = Array.isArray(message.content) ? (message.content as PromptPart[]) : [];
 
-    if (message?.role === 'assistant') {
-      for (const part of content) {
-        if (
-          (part?.type === 'tool-call' || part?.type === 'tool') &&
-          typeof part?.toolCallId === 'string'
-        ) {
-          toolCallInputs.set(part.toolCallId, part.input ?? part.args);
-        }
-      }
+    if (message.role === 'assistant') {
+      collectAssistantToolInputs(content, toolCallInputs);
       continue;
     }
 
-    if (message?.role !== 'tool') {
+    if (message.role !== 'tool') {
       continue;
     }
 
-    for (const part of content) {
-      if (part?.type !== 'tool-result') {
-        continue;
-      }
-
-      const toolCallId = typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
-      results.push({
-        toolName: part.toolName ?? 'unknown',
-        toolCallId,
-        input: toolCallId ? toolCallInputs.get(toolCallId) : undefined,
-        output: part.output,
-      });
-    }
+    appendPromptToolResults(content, toolCallInputs, results);
   }
 
   return results;
+}
+
+function collectAssistantToolInputs(
+  content: PromptPart[],
+  toolCallInputs: Map<string, unknown>
+): void {
+  for (const part of content) {
+    if (!isToolCallPart(part) || typeof part.toolCallId !== 'string') {
+      continue;
+    }
+
+    toolCallInputs.set(part.toolCallId, part.input ?? part.args);
+  }
+}
+
+function appendPromptToolResults(
+  content: PromptPart[],
+  toolCallInputs: Map<string, unknown>,
+  results: PromptToolResult[]
+): void {
+  for (const part of content) {
+    if (!isToolResultPart(part)) {
+      continue;
+    }
+
+    const toolCallId = typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
+    results.push({
+      toolName: typeof part.toolName === 'string' ? part.toolName : 'unknown',
+      toolCallId,
+      input: toolCallId ? toolCallInputs.get(toolCallId) : undefined,
+      output: part.output,
+    });
+  }
 }
 
 function emitToolResultSpansFromPrompt(
   tracer: Tracer,
   span: Span,
   toolResults: PromptToolResult[],
-  seenToolCallIds: Set<string>
+  seenToolCallIds: Set<string>,
+  captureState: ToolCaptureState,
+  toolSpanTypes?: Record<string, string>
 ): void {
   if (toolResults.length === 0) {
     return;
@@ -255,6 +318,14 @@ function emitToolResultSpansFromPrompt(
 
   SpanContext.run(span, () => {
     for (const toolResult of toolResults) {
+      if (toolResult.toolCallId) {
+        if (captureState.executedToolCallIds.has(toolResult.toolCallId)) {
+          continue;
+        }
+      } else if (captureState.executedToolNames.has(toolResult.toolName)) {
+        continue;
+      }
+
       if (toolResult.toolCallId) {
         if (seenToolCallIds.has(toolResult.toolCallId)) {
           continue;
@@ -264,17 +335,16 @@ function emitToolResultSpansFromPrompt(
 
       const toolSpan = tracer.startSpan({
         name: 'ai:tool-call',
-        spanType: toAiSpanType(SpanType.TOOL),
-        inputs: {
-          'ai.tool.name': toolResult.toolName,
+        spanType: resolveToolSpanType(toolResult.toolName, toolSpanTypes),
+        inputs: createToolSpanInputs({
           toolName: toolResult.toolName,
-          ...(toolResult.toolCallId ? { toolCallId: toolResult.toolCallId } : {}),
-          ...(toolResult.input !== undefined ? { input: toolResult.input } : {}),
-        },
+          toolCallId: toolResult.toolCallId,
+          input: toolResult.input,
+        }),
       });
 
       tracer.endSpan(toolSpan, {
-        outputs: { output: normalizeToolResultOutput(toolResult.output) },
+        outputs: createToolSpanOutputs(toolResult.output),
       });
     }
   });
@@ -304,8 +374,7 @@ const MODEL_SETTINGS = [
  * @internal
  */
 function extractInputs(
-  // biome-ignore lint/suspicious/noExplicitAny: AI SDK params are dynamic
-  params: any,
+  params: Record<string, unknown>,
   config?: MiddlewareConfig
 ): Record<string, unknown> {
   const inputs: Record<string, unknown> = {};
@@ -322,27 +391,43 @@ function extractInputs(
     inputs['ai.prompt'] = params.prompt;
   }
 
-  // Capture tools if enabled
-  if (config?.captureTools !== false && params.tools) {
-    // AI SDK v4 uses an object map; normalize to names to avoid serializing tool functions.
-    if (Array.isArray(params.tools)) {
-      inputs['ai.tools'] = params.tools.map((tool: { name?: string; description?: string }) => ({
-        name: tool.name,
-        description: tool.description,
-      }));
-    } else if (typeof params.tools === 'object') {
-      inputs['ai.tools'] = Object.entries(
-        params.tools as Record<string, { description?: string } | undefined>
-      ).map(([name, tool]) => ({
-        name,
-        description: typeof tool?.description === 'string' ? tool.description : undefined,
-      }));
-    } else {
-      inputs['ai.tools'] = params.tools;
-    }
+  const serializedTools =
+    config?.captureTools === false ? undefined : serializeToolsForInputs(params.tools);
+  if (serializedTools !== undefined) {
+    inputs['ai.tools'] = serializedTools;
   }
 
   return inputs;
+}
+
+function serializeToolsForInputs(tools: unknown): unknown {
+  if (tools === undefined) {
+    return undefined;
+  }
+
+  if (Array.isArray(tools)) {
+    return tools.map((tool) => {
+      const typedTool = getToolDefinition(tool);
+      return typedTool
+        ? {
+            name: typedTool.name,
+            description: typedTool.description,
+          }
+        : tool;
+    });
+  }
+
+  if (isRecord(tools)) {
+    return Object.entries(tools).map(([name, tool]) => {
+      const typedTool = getToolDefinition(tool);
+      return {
+        name,
+        description: typedTool?.description,
+      };
+    });
+  }
+
+  return tools;
 }
 
 /**
@@ -354,8 +439,7 @@ function extractInputs(
  * @internal
  */
 function extractOutputs(
-  // biome-ignore lint/suspicious/noExplicitAny: AI SDK result structure is dynamic
-  result: any,
+  result: Record<string, unknown>,
   config?: MiddlewareConfig
 ): Record<string, unknown> {
   const outputs: Record<string, unknown> = {};
@@ -369,36 +453,56 @@ function extractOutputs(
 
   // Capture response content if enabled
   if (config?.captureContent !== false) {
-    if (result.text) {
-      outputs['ai.response.text'] = result.text;
-    }
     if (content) {
       outputs['ai.response.content'] = content;
-      const textParts = content
-        .filter(
-          (part: { type: string; text: string }) =>
-            part?.type === 'text' && typeof part.text === 'string'
-        )
-        .map((part: { text: string }) => part.text);
-      if (textParts.length > 0) {
-        outputs['ai.response.text'] = textParts.join('');
-      }
+    }
+
+    const responseText = extractResponseText(result, content);
+    if (responseText !== undefined) {
+      outputs['ai.response.text'] = responseText;
     }
   }
 
-  // Capture tool calls if enabled
-  if (config?.captureTools !== false) {
-    if (result.toolCalls) {
-      outputs['ai.response.toolCalls'] = result.toolCalls;
-    } else if (content) {
-      const toolCalls = content.filter((part: { type: string }) => part?.type === 'tool-call');
-      if (toolCalls.length > 0) {
-        outputs['ai.response.toolCalls'] = toolCalls;
-      }
-    }
+  const toolCalls =
+    config?.captureTools === false ? undefined : extractResponseToolCalls(result, content);
+  if (toolCalls !== undefined) {
+    outputs['ai.response.toolCalls'] = toolCalls;
   }
 
   return outputs;
+}
+
+function extractResponseText(
+  result: Record<string, unknown>,
+  content: unknown[] | undefined
+): string | undefined {
+  const contentText = content ? extractContentText(content) : undefined;
+  if (contentText !== undefined) {
+    return contentText;
+  }
+
+  return typeof result.text === 'string' ? result.text : undefined;
+}
+
+function extractContentText(content: unknown[]): string | undefined {
+  const textParts = content.filter(isTextContentPart).map((part) => part.text);
+  return textParts.length > 0 ? textParts.join('') : undefined;
+}
+
+function extractResponseToolCalls(
+  result: Record<string, unknown>,
+  content: unknown[] | undefined
+): unknown {
+  if (result.toolCalls !== undefined) {
+    return result.toolCalls;
+  }
+
+  if (!content) {
+    return undefined;
+  }
+
+  const toolCalls = content.filter(isToolCallPart);
+  return toolCalls.length > 0 ? toolCalls : undefined;
 }
 
 /**
@@ -408,39 +512,44 @@ function extractOutputs(
  * @returns TokenUsage object or undefined
  * @internal
  */
-function extractTokenUsage(
-  // biome-ignore lint/suspicious/noExplicitAny: AI SDK result structure varies by provider
-  result: any
-): TokenUsage | undefined {
-  if (!result.usage) {
+function extractTokenUsage(result: Record<string, unknown>): TokenUsage | undefined {
+  if (!isRecord(result.usage)) {
     return undefined;
   }
 
-  const usage = result.usage;
+  return extractStructuredTokenUsage(result.usage) ?? extractLegacyTokenUsage(result.usage);
+}
 
-  // Handle V3 usage format (inputTokens/outputTokens objects)
-  if (usage.inputTokens || usage.outputTokens) {
-    const promptTokens = usage.inputTokens?.total ?? 0;
-    const completionTokens = usage.outputTokens?.total ?? 0;
-    return {
-      promptTokens,
-      completionTokens,
-      totalTokens: promptTokens + completionTokens,
-    };
+function extractStructuredTokenUsage(usage: Record<string, unknown>): TokenUsage | undefined {
+  if (usage.inputTokens === undefined && usage.outputTokens === undefined) {
+    return undefined;
   }
 
-  // Handle V1 usage format (promptTokens/completionTokens)
-  if (usage.promptTokens !== undefined || usage.completionTokens !== undefined) {
-    const promptTokens = usage.promptTokens ?? 0;
-    const completionTokens = usage.completionTokens ?? 0;
-    return {
-      promptTokens,
-      completionTokens,
-      totalTokens: promptTokens + completionTokens,
-    };
+  const promptTokens = getNestedTokenTotal(usage.inputTokens);
+  const completionTokens = getNestedTokenTotal(usage.outputTokens);
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+  };
+}
+
+function extractLegacyTokenUsage(usage: Record<string, unknown>): TokenUsage | undefined {
+  if (usage.promptTokens === undefined && usage.completionTokens === undefined) {
+    return undefined;
   }
 
-  return undefined;
+  const promptTokens = typeof usage.promptTokens === 'number' ? usage.promptTokens : 0;
+  const completionTokens = typeof usage.completionTokens === 'number' ? usage.completionTokens : 0;
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+  };
+}
+
+function getNestedTokenTotal(value: unknown): number {
+  return isRecord(value) && typeof value.total === 'number' ? value.total : 0;
 }
 
 /**
@@ -456,17 +565,15 @@ function extractTokenUsage(
  */
 function createLlmSpan(
   tracer: Tracer,
-  // biome-ignore lint/suspicious/noExplicitAny: AI SDK model structure is dynamic
-  model: any,
-  // biome-ignore lint/suspicious/noExplicitAny: AI SDK params are dynamic
-  params: any,
+  model: Record<string, unknown>,
+  params: Record<string, unknown>,
   config?: MiddlewareConfig,
   parentSpan?: Span
 ): Span {
   const modelName = `${model.provider ?? 'unknown'}.${model.modelId ?? 'unknown'}`;
   const spanOptions = {
     name: 'ai:llm-call',
-    spanType: toAiSpanType(SpanType.LLM),
+    spanType: `ai-sdk:${SpanType.LLM}`,
     inputs: {
       'ai.model.name': modelName,
       'ai.model.id': model.modelId,
@@ -479,6 +586,22 @@ function createLlmSpan(
     return SpanContext.run(parentSpan, () => tracer.startSpan(spanOptions));
   }
   return tracer.startSpan(spanOptions);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isToolCallPart(part: unknown): part is PromptPart {
+  return isRecord(part) && (part.type === 'tool-call' || part.type === 'tool');
+}
+
+function isToolResultPart(part: unknown): part is PromptPart {
+  return isRecord(part) && part.type === 'tool-result';
+}
+
+function isTextContentPart(part: unknown): part is PromptPart & { text: string } {
+  return isRecord(part) && part.type === 'text' && typeof part.text === 'string';
 }
 
 /**
@@ -515,12 +638,14 @@ export function createPrefactorMiddleware(
     agentInfo?: Parameters<AgentInstanceManager['startInstance']>[0];
     agentLifecycle?: { started: boolean };
     deadTimeoutMs?: number;
+    toolSpanTypes?: Record<string, string>;
   }
 ): LanguageModelMiddleware {
   const agentManager = coreOptions?.agentManager;
   const agentInfo = coreOptions?.agentInfo;
   const agentLifecycle = coreOptions?.agentLifecycle ?? { started: false };
   const deadTimeoutMs = coreOptions?.deadTimeoutMs ?? AGENT_DEAD_TIMEOUT_MS;
+  const toolSpanTypes = coreOptions?.toolSpanTypes;
 
   function ensureAgentInstanceStarted(): void {
     if (!agentManager || agentLifecycle.started) {
@@ -533,7 +658,7 @@ export function createPrefactorMiddleware(
   return {
     specificationVersion: 'v3',
     transformParams: async ({ params }) =>
-      config?.captureTools === false ? params : wrapToolsInParams(params, tracer),
+      config?.captureTools === false ? params : wrapToolsInParams(params, tracer, toolSpanTypes),
     /**
      * Wraps non-streaming generation calls.
      */
@@ -544,23 +669,29 @@ export function createPrefactorMiddleware(
       const parentSpan = SpanContext.getCurrent();
       const span = createLlmSpan(tracer, model, params, config, parentSpan);
       const seenToolCallIds = new Set<string>();
-
-      if (config?.captureTools !== false && !hasExecutableToolsInParams(params)) {
-        emitToolResultSpansFromPrompt(
-          tracer,
-          span,
-          extractPromptToolResults(params),
-          seenToolCallIds
-        );
-      }
+      const captureState = createToolCaptureState();
 
       try {
         // Execute the generation within the LLM span context
         const result = await runWithTimeout(
-          () => SpanContext.runAsync(span, () => Promise.resolve(doGenerate())),
+          () =>
+            TOOL_CAPTURE_STATE_STORAGE.run(captureState, () =>
+              SpanContext.runAsync(span, () => Promise.resolve(doGenerate()))
+            ),
           deadTimeoutMs,
           'Agent did not respond within timeout duration and was marked as failed.'
         );
+
+        if (config?.captureTools !== false) {
+          emitToolResultSpansFromPrompt(
+            tracer,
+            span,
+            extractPromptToolResults(params),
+            seenToolCallIds,
+            captureState,
+            toolSpanTypes
+          );
+        }
 
         // End the span with outputs
         tracer.endSpan(span, {
@@ -588,23 +719,29 @@ export function createPrefactorMiddleware(
       const parentSpan = SpanContext.getCurrent();
       const span = createLlmSpan(tracer, model, params, config, parentSpan);
       const seenToolCallIds = new Set<string>();
-
-      if (config?.captureTools !== false && !hasExecutableToolsInParams(params)) {
-        emitToolResultSpansFromPrompt(
-          tracer,
-          span,
-          extractPromptToolResults(params),
-          seenToolCallIds
-        );
-      }
+      const captureState = createToolCaptureState();
 
       try {
         // Execute the stream within the span context
         const result = await runWithTimeout(
-          () => SpanContext.runAsync(span, () => Promise.resolve(doStream())),
+          () =>
+            TOOL_CAPTURE_STATE_STORAGE.run(captureState, () =>
+              SpanContext.runAsync(span, () => Promise.resolve(doStream()))
+            ),
           deadTimeoutMs,
           'Agent did not respond within timeout duration and was marked as failed.'
         );
+
+        if (config?.captureTools !== false) {
+          emitToolResultSpansFromPrompt(
+            tracer,
+            span,
+            extractPromptToolResults(params),
+            seenToolCallIds,
+            captureState,
+            toolSpanTypes
+          );
+        }
 
         // Wrap the stream to capture completion
         const wrappedStream = wrapStreamForCompletion(result.stream, span, tracer, config);
@@ -634,21 +771,18 @@ export function createPrefactorMiddleware(
  * @returns A wrapped stream that ends the span on completion
  * @internal
  */
-function wrapStreamForCompletion(
-  // biome-ignore lint/suspicious/noExplicitAny: Stream part types vary
-  stream: ReadableStream<any>,
+function wrapStreamForCompletion<T>(
+  stream: ReadableStream<T>,
   span: Span,
   tracer: Tracer,
   config?: MiddlewareConfig
-  // biome-ignore lint/suspicious/noExplicitAny: Stream part types vary
-): ReadableStream<any> {
+): ReadableStream<T> {
   const reader = stream.getReader();
   let finishReason: unknown | undefined;
   let usage: TokenUsage | undefined;
-  // biome-ignore lint/suspicious/noExplicitAny: Collecting stream chunks
-  const textChunks: any[] = [];
+  const textChunks: string[] = [];
 
-  return new ReadableStream({
+  return new ReadableStream<T>({
     async pull(controller) {
       try {
         const { done, value } = await reader.read();
@@ -675,24 +809,16 @@ function wrapStreamForCompletion(
         }
 
         // Capture stream parts for telemetry
-        const part = value;
+        const part = getStreamPart(value);
         if (part) {
-          // Capture text chunks
-          if (part.type === 'text-delta') {
-            const delta = part.delta ?? part.textDelta;
-            if (delta) {
-              textChunks.push(delta);
-            }
+          const delta = extractTextDelta(part);
+          if (delta !== undefined) {
+            textChunks.push(delta);
           }
 
-          // Capture finish reason
-          if (part.type === 'finish' && part.finishReason) {
-            finishReason = part.finishReason;
-          }
-
-          // Capture usage from finish part
-          if (part.type === 'finish' && part.usage) {
-            usage = extractTokenUsage({ usage: part.usage });
+          if (part.type === 'finish') {
+            finishReason = part.finishReason ?? finishReason;
+            usage = part.usage ? extractTokenUsage({ usage: part.usage }) : usage;
           }
         }
 
@@ -712,4 +838,20 @@ function wrapStreamForCompletion(
       reader.cancel();
     },
   });
+}
+
+function getStreamPart(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function extractTextDelta(part: Record<string, unknown>): string | undefined {
+  if (part.type !== 'text-delta') {
+    return undefined;
+  }
+
+  if (typeof part.delta === 'string') {
+    return part.delta;
+  }
+
+  return typeof part.textDelta === 'string' ? part.textDelta : undefined;
 }

--- a/packages/ai/src/middleware.ts
+++ b/packages/ai/src/middleware.ts
@@ -250,10 +250,15 @@ function extractToolCallId(args: unknown[]): string | undefined {
 
 function extractPromptToolResults(params: Record<string, unknown>): PromptToolResult[] {
   const prompt = Array.isArray(params.prompt) ? (params.prompt as PromptMessage[]) : [];
+  const trailingToolMessageStartIndex = findTrailingToolMessageStartIndex(prompt);
+  if (trailingToolMessageStartIndex === -1) {
+    return [];
+  }
+
   const toolCallInputs = new Map<string, unknown>();
   const results: PromptToolResult[] = [];
 
-  for (const message of prompt) {
+  for (const [index, message] of prompt.entries()) {
     const content = Array.isArray(message.content) ? (message.content as PromptPart[]) : [];
 
     if (message.role === 'assistant') {
@@ -261,7 +266,7 @@ function extractPromptToolResults(params: Record<string, unknown>): PromptToolRe
       continue;
     }
 
-    if (message.role !== 'tool') {
+    if (message.role !== 'tool' || index < trailingToolMessageStartIndex) {
       continue;
     }
 
@@ -269,6 +274,19 @@ function extractPromptToolResults(params: Record<string, unknown>): PromptToolRe
   }
 
   return results;
+}
+
+function findTrailingToolMessageStartIndex(prompt: PromptMessage[]): number {
+  if (prompt.length === 0 || prompt.at(-1)?.role !== 'tool') {
+    return -1;
+  }
+
+  let index = prompt.length - 1;
+  while (index >= 0 && prompt[index]?.role === 'tool') {
+    index -= 1;
+  }
+
+  return index + 1;
 }
 
 function collectAssistantToolInputs(

--- a/packages/ai/src/provider.ts
+++ b/packages/ai/src/provider.ts
@@ -1,16 +1,10 @@
-import type {
-  AgentInstanceManager,
-  Config,
-  MiddlewareLike,
-  PrefactorProvider,
-  Tracer,
-} from '@prefactor/core';
+import type { AgentInstanceManager, Config, PrefactorProvider, Tracer } from '@prefactor/core';
 import { createPrefactorMiddleware } from './middleware.js';
 import {
   DEFAULT_AI_AGENT_SCHEMA as DEFAULT_AI_AGENT_SCHEMA_BASE,
   normalizeAgentSchema,
 } from './schema.js';
-import type { MiddlewareConfig } from './types.js';
+import type { LanguageModelMiddleware, MiddlewareConfig } from './types.js';
 
 export const DEFAULT_AI_AGENT_SCHEMA = DEFAULT_AI_AGENT_SCHEMA_BASE;
 
@@ -19,9 +13,11 @@ export interface PrefactorAISDKOptions {
   agentSchema?: Record<string, unknown>;
 }
 
-export class PrefactorAISDK implements PrefactorProvider {
+export class PrefactorAISDK implements PrefactorProvider<LanguageModelMiddleware> {
   private readonly options: PrefactorAISDKOptions;
   private toolSpanTypes: Record<string, string> | undefined;
+  private agentManager: AgentInstanceManager | null = null;
+  private agentLifecycle: { started: boolean } | null = null;
 
   constructor(options: PrefactorAISDKOptions = {}) {
     this.options = options;
@@ -31,7 +27,8 @@ export class PrefactorAISDK implements PrefactorProvider {
     tracer: Tracer,
     agentManager: AgentInstanceManager,
     coreConfig: Config
-  ): MiddlewareLike {
+  ): LanguageModelMiddleware {
+    this.agentManager = agentManager;
     const httpConfig = coreConfig.httpConfig;
     const agentInfo = httpConfig
       ? {
@@ -43,6 +40,7 @@ export class PrefactorAISDK implements PrefactorProvider {
       : undefined;
 
     const agentLifecycle = { started: false };
+    this.agentLifecycle = agentLifecycle;
 
     return createPrefactorMiddleware(tracer, this.options.middleware, {
       agentManager,
@@ -51,6 +49,16 @@ export class PrefactorAISDK implements PrefactorProvider {
       deadTimeoutMs: 5 * 60 * 1000,
       toolSpanTypes: this.toolSpanTypes,
     });
+  }
+
+  shutdown(): void {
+    if (this.agentLifecycle?.started) {
+      this.agentManager?.finishInstance();
+      this.agentLifecycle.started = false;
+    }
+
+    this.agentManager = null;
+    this.agentLifecycle = null;
   }
 
   normalizeAgentSchema(agentSchema: Record<string, unknown>): Record<string, unknown> {

--- a/packages/ai/src/provider.ts
+++ b/packages/ai/src/provider.ts
@@ -1,25 +1,18 @@
 import type {
   AgentInstanceManager,
+  Config,
   MiddlewareLike,
   PrefactorProvider,
   Tracer,
 } from '@prefactor/core';
 import { createPrefactorMiddleware } from './middleware.js';
+import {
+  DEFAULT_AI_AGENT_SCHEMA as DEFAULT_AI_AGENT_SCHEMA_BASE,
+  normalizeAgentSchema,
+} from './schema.js';
 import type { MiddlewareConfig } from './types.js';
 
-export const DEFAULT_AI_AGENT_SCHEMA = {
-  external_identifier: 'ai-sdk-schema',
-  span_schemas: {
-    'ai-sdk:agent': { type: 'object', additionalProperties: true },
-    'ai-sdk:llm': { type: 'object', additionalProperties: true },
-    'ai-sdk:tool': { type: 'object', additionalProperties: true },
-  },
-  span_result_schemas: {
-    'ai-sdk:agent': { type: 'object', additionalProperties: true },
-    'ai-sdk:llm': { type: 'object', additionalProperties: true },
-    'ai-sdk:tool': { type: 'object', additionalProperties: true },
-  },
-} as const;
+export const DEFAULT_AI_AGENT_SCHEMA = DEFAULT_AI_AGENT_SCHEMA_BASE;
 
 export interface PrefactorAISDKOptions {
   middleware?: MiddlewareConfig;
@@ -28,6 +21,7 @@ export interface PrefactorAISDKOptions {
 
 export class PrefactorAISDK implements PrefactorProvider {
   private readonly options: PrefactorAISDKOptions;
+  private toolSpanTypes: Record<string, string> | undefined;
 
   constructor(options: PrefactorAISDKOptions = {}) {
     this.options = options;
@@ -36,8 +30,7 @@ export class PrefactorAISDK implements PrefactorProvider {
   createMiddleware(
     tracer: Tracer,
     agentManager: AgentInstanceManager,
-    // biome-ignore lint/suspicious/noExplicitAny: Config shape varies by version
-    coreConfig: any
+    coreConfig: Config
   ): MiddlewareLike {
     const httpConfig = coreConfig.httpConfig;
     const agentInfo = httpConfig
@@ -56,7 +49,14 @@ export class PrefactorAISDK implements PrefactorProvider {
       agentInfo,
       agentLifecycle,
       deadTimeoutMs: 5 * 60 * 1000,
+      toolSpanTypes: this.toolSpanTypes,
     });
+  }
+
+  normalizeAgentSchema(agentSchema: Record<string, unknown>): Record<string, unknown> {
+    const normalizedSchema = normalizeAgentSchema(agentSchema);
+    this.toolSpanTypes = normalizedSchema.toolSpanTypes;
+    return normalizedSchema.agentSchema;
   }
 
   getDefaultAgentSchema(): Record<string, unknown> | undefined {

--- a/packages/ai/src/schema.ts
+++ b/packages/ai/src/schema.ts
@@ -1,0 +1,248 @@
+import { buildToolSpanSchema, GENERIC_OBJECT_SCHEMA } from './tool-span-contract.js';
+import type { JsonSchema, ToolSchemaConfig } from './types.js';
+
+interface NormalizedAISchemaData {
+  agentSchema: Record<string, unknown>;
+  toolSpanTypes?: Record<string, string>;
+}
+
+export const DEFAULT_AI_AGENT_SCHEMA = {
+  external_identifier: 'ai-sdk-schema',
+  span_schemas: {
+    'ai-sdk:agent': { type: 'object', additionalProperties: true },
+    'ai-sdk:llm': { type: 'object', additionalProperties: true },
+    'ai-sdk:tool': { type: 'object', additionalProperties: true },
+  },
+  span_result_schemas: {
+    'ai-sdk:agent': { type: 'object', additionalProperties: true },
+    'ai-sdk:llm': { type: 'object', additionalProperties: true },
+    'ai-sdk:tool': { type: 'object', additionalProperties: true },
+  },
+} as const satisfies Record<string, unknown>;
+
+export function normalizeAgentSchema(
+  agentSchema: Record<string, unknown> | undefined
+): NormalizedAISchemaData {
+  const toolSchemas = extractToolSchemas(agentSchema);
+  return {
+    agentSchema: buildAgentSchema(agentSchema, toolSchemas),
+    toolSpanTypes: buildToolSpanTypes(toolSchemas),
+  };
+}
+
+export function resolveToolSpanType(
+  toolName: string,
+  toolSpanTypes: Record<string, string> | undefined
+): string {
+  return toolSpanTypes?.[toolName] ?? 'ai-sdk:tool';
+}
+
+function buildAgentSchema(
+  baseSchema: Record<string, unknown> | undefined,
+  toolSchemas: Record<string, ToolSchemaConfig> | undefined
+): Record<string, unknown> {
+  const base = mergeWithDefaultAgentSchema(stripToolSchemas(baseSchema));
+  if (!toolSchemas) {
+    return base;
+  }
+
+  const spanSchemas = cloneRecord(base.span_schemas);
+  const spanResultSchemas = cloneRecord(base.span_result_schemas);
+
+  for (const { spanType, inputSchema } of Object.values(toolSchemas)) {
+    if (!spanSchemas[spanType]) {
+      spanSchemas[spanType] = buildToolSpanSchema(inputSchema);
+    }
+    if (!spanResultSchemas[spanType]) {
+      spanResultSchemas[spanType] = GENERIC_OBJECT_SCHEMA;
+    }
+  }
+
+  return {
+    ...base,
+    span_schemas: spanSchemas,
+    span_result_schemas: spanResultSchemas,
+  };
+}
+
+function extractToolSchemas(
+  agentSchema: Record<string, unknown> | undefined
+): Record<string, ToolSchemaConfig> | undefined {
+  const rawToolSchemas = getRawToolSchemas(agentSchema);
+  if (!rawToolSchemas) {
+    return undefined;
+  }
+
+  const toolSchemas: Record<string, ToolSchemaConfig> = {};
+  const toolBySpanType = new Map<string, string>();
+  for (const [toolName, rawConfig] of Object.entries(rawToolSchemas)) {
+    toolSchemas[toolName] = parseToolSchemaConfig(toolName, rawConfig, toolBySpanType);
+  }
+
+  return Object.keys(toolSchemas).length > 0 ? toolSchemas : undefined;
+}
+
+function getRawToolSchemas(
+  agentSchema: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!agentSchema || typeof agentSchema !== 'object' || Array.isArray(agentSchema)) {
+    return undefined;
+  }
+
+  const rawToolSchemas = (agentSchema as { toolSchemas?: unknown }).toolSchemas;
+  if (rawToolSchemas === undefined) {
+    return undefined;
+  }
+
+  if (!rawToolSchemas || typeof rawToolSchemas !== 'object' || Array.isArray(rawToolSchemas)) {
+    throw new Error('Invalid agentSchema.toolSchemas: expected an object keyed by tool name.');
+  }
+
+  return rawToolSchemas as Record<string, unknown>;
+}
+
+function parseToolSchemaConfig(
+  toolName: string,
+  rawConfig: unknown,
+  toolBySpanType: Map<string, string>
+): ToolSchemaConfig {
+  if (!rawConfig || typeof rawConfig !== 'object' || Array.isArray(rawConfig)) {
+    throw new Error(
+      `Invalid agentSchema.toolSchemas.${toolName}: expected an object with spanType and inputSchema.`
+    );
+  }
+
+  const config = rawConfig as {
+    spanType?: unknown;
+    inputSchema?: unknown;
+  };
+
+  if (typeof config.spanType !== 'string') {
+    throw new Error(
+      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty string.`
+    );
+  }
+
+  const inputSchema = assertValidInputSchema(toolName, config.inputSchema);
+  const normalizedSpanType = normalizeUniqueToolSpanType(toolName, config.spanType, toolBySpanType);
+  return {
+    spanType: normalizedSpanType,
+    inputSchema,
+  };
+}
+
+function assertValidInputSchema(toolName: string, inputSchema: unknown): JsonSchema {
+  if (!inputSchema || typeof inputSchema !== 'object' || Array.isArray(inputSchema)) {
+    throw new Error(`Invalid agentSchema.toolSchemas.${toolName}.inputSchema: expected an object.`);
+  }
+
+  return inputSchema as JsonSchema;
+}
+
+function normalizeUniqueToolSpanType(
+  toolName: string,
+  spanType: string,
+  toolBySpanType: Map<string, string>
+): string {
+  const normalizedSpanType = normalizeToolSpanType(spanType, toolName);
+  const conflictingTool = toolBySpanType.get(normalizedSpanType);
+  if (conflictingTool && conflictingTool !== toolName) {
+    throw new Error(
+      `Invalid agentSchema.toolSchemas.${toolName}.spanType: normalized span type "${normalizedSpanType}" conflicts with "${conflictingTool}".`
+    );
+  }
+
+  toolBySpanType.set(normalizedSpanType, toolName);
+  return normalizedSpanType;
+}
+
+function buildToolSpanTypes(
+  toolSchemas: Record<string, ToolSchemaConfig> | undefined
+): Record<string, string> | undefined {
+  if (!toolSchemas) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(toolSchemas).map(([toolName, config]) => [toolName, config.spanType])
+  );
+}
+
+function cloneRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return { ...(value as Record<string, unknown>) };
+}
+
+function stripToolSchemas(
+  baseSchema: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!baseSchema || typeof baseSchema !== 'object' || Array.isArray(baseSchema)) {
+    return baseSchema;
+  }
+
+  const { toolSchemas: _, ...rest } = baseSchema as Record<string, unknown> & {
+    toolSchemas?: unknown;
+  };
+
+  return rest;
+}
+
+function mergeWithDefaultAgentSchema(
+  baseSchema: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (!baseSchema) {
+    return DEFAULT_AI_AGENT_SCHEMA;
+  }
+
+  return {
+    ...DEFAULT_AI_AGENT_SCHEMA,
+    ...baseSchema,
+    span_schemas: {
+      ...cloneRecord(DEFAULT_AI_AGENT_SCHEMA.span_schemas),
+      ...cloneRecord(baseSchema.span_schemas),
+    },
+    span_result_schemas: {
+      ...cloneRecord(DEFAULT_AI_AGENT_SCHEMA.span_result_schemas),
+      ...cloneRecord(baseSchema.span_result_schemas),
+    },
+  };
+}
+
+function normalizeToolSpanType(spanType: string, toolName: string): string {
+  const trimmedSpanType = spanType.trim();
+  if (trimmedSpanType.length === 0) {
+    throw new Error(
+      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty string.`
+    );
+  }
+
+  if (trimmedSpanType.startsWith('ai-sdk:tool:')) {
+    const suffix = trimmedSpanType.slice('ai-sdk:tool:'.length).replace(/^:+/, '');
+    if (suffix.length === 0) {
+      throw new Error(
+        `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty suffix after normalization.`
+      );
+    }
+    return `ai-sdk:tool:${suffix}`;
+  }
+
+  let suffix = trimmedSpanType;
+  if (suffix.startsWith('ai-sdk:')) {
+    suffix = suffix.slice('ai-sdk:'.length);
+  }
+  if (suffix.startsWith('tool:')) {
+    suffix = suffix.slice('tool:'.length);
+  }
+
+  suffix = suffix.replace(/^:+/, '');
+  if (suffix.length === 0) {
+    throw new Error(
+      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty suffix after normalization.`
+    );
+  }
+
+  return `ai-sdk:tool:${suffix}`;
+}

--- a/packages/ai/src/schema.ts
+++ b/packages/ai/src/schema.ts
@@ -1,5 +1,5 @@
+import { normalizeAgentToolSchemas, resolveMappedSpanType } from '@prefactor/core';
 import { buildToolSpanSchema, GENERIC_OBJECT_SCHEMA } from './tool-span-contract.js';
-import type { JsonSchema, ToolSchemaConfig } from './types.js';
 
 interface NormalizedAISchemaData {
   agentSchema: Record<string, unknown>;
@@ -23,10 +23,14 @@ export const DEFAULT_AI_AGENT_SCHEMA = {
 export function normalizeAgentSchema(
   agentSchema: Record<string, unknown> | undefined
 ): NormalizedAISchemaData {
-  const toolSchemas = extractToolSchemas(agentSchema);
+  const normalizedToolSchemas = normalizeAgentToolSchemas(agentSchema, {
+    defaultAgentSchema: DEFAULT_AI_AGENT_SCHEMA,
+    providerName: 'ai-sdk',
+  });
+
   return {
-    agentSchema: buildAgentSchema(agentSchema, toolSchemas),
-    toolSpanTypes: buildToolSpanTypes(toolSchemas),
+    agentSchema: buildAgentSchema(normalizedToolSchemas),
+    toolSpanTypes: normalizedToolSchemas.toolSpanTypes,
   };
 }
 
@@ -34,14 +38,14 @@ export function resolveToolSpanType(
   toolName: string,
   toolSpanTypes: Record<string, string> | undefined
 ): string {
-  return toolSpanTypes?.[toolName] ?? 'ai-sdk:tool';
+  return resolveMappedSpanType(toolName, toolSpanTypes, 'ai-sdk:tool');
 }
 
 function buildAgentSchema(
-  baseSchema: Record<string, unknown> | undefined,
-  toolSchemas: Record<string, ToolSchemaConfig> | undefined
+  normalizedToolSchemas: ReturnType<typeof normalizeAgentToolSchemas>
 ): Record<string, unknown> {
-  const base = mergeWithDefaultAgentSchema(stripToolSchemas(baseSchema));
+  const base = normalizedToolSchemas.agentSchema;
+  const toolSchemas = normalizedToolSchemas.toolSchemas;
   if (!toolSchemas) {
     return base;
   }
@@ -65,184 +69,10 @@ function buildAgentSchema(
   };
 }
 
-function extractToolSchemas(
-  agentSchema: Record<string, unknown> | undefined
-): Record<string, ToolSchemaConfig> | undefined {
-  const rawToolSchemas = getRawToolSchemas(agentSchema);
-  if (!rawToolSchemas) {
-    return undefined;
-  }
-
-  const toolSchemas: Record<string, ToolSchemaConfig> = {};
-  const toolBySpanType = new Map<string, string>();
-  for (const [toolName, rawConfig] of Object.entries(rawToolSchemas)) {
-    toolSchemas[toolName] = parseToolSchemaConfig(toolName, rawConfig, toolBySpanType);
-  }
-
-  return Object.keys(toolSchemas).length > 0 ? toolSchemas : undefined;
-}
-
-function getRawToolSchemas(
-  agentSchema: Record<string, unknown> | undefined
-): Record<string, unknown> | undefined {
-  if (!agentSchema || typeof agentSchema !== 'object' || Array.isArray(agentSchema)) {
-    return undefined;
-  }
-
-  const rawToolSchemas = (agentSchema as { toolSchemas?: unknown }).toolSchemas;
-  if (rawToolSchemas === undefined) {
-    return undefined;
-  }
-
-  if (!rawToolSchemas || typeof rawToolSchemas !== 'object' || Array.isArray(rawToolSchemas)) {
-    throw new Error('Invalid agentSchema.toolSchemas: expected an object keyed by tool name.');
-  }
-
-  return rawToolSchemas as Record<string, unknown>;
-}
-
-function parseToolSchemaConfig(
-  toolName: string,
-  rawConfig: unknown,
-  toolBySpanType: Map<string, string>
-): ToolSchemaConfig {
-  if (!rawConfig || typeof rawConfig !== 'object' || Array.isArray(rawConfig)) {
-    throw new Error(
-      `Invalid agentSchema.toolSchemas.${toolName}: expected an object with spanType and inputSchema.`
-    );
-  }
-
-  const config = rawConfig as {
-    spanType?: unknown;
-    inputSchema?: unknown;
-  };
-
-  if (typeof config.spanType !== 'string') {
-    throw new Error(
-      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty string.`
-    );
-  }
-
-  const inputSchema = assertValidInputSchema(toolName, config.inputSchema);
-  const normalizedSpanType = normalizeUniqueToolSpanType(toolName, config.spanType, toolBySpanType);
-  return {
-    spanType: normalizedSpanType,
-    inputSchema,
-  };
-}
-
-function assertValidInputSchema(toolName: string, inputSchema: unknown): JsonSchema {
-  if (!inputSchema || typeof inputSchema !== 'object' || Array.isArray(inputSchema)) {
-    throw new Error(`Invalid agentSchema.toolSchemas.${toolName}.inputSchema: expected an object.`);
-  }
-
-  return inputSchema as JsonSchema;
-}
-
-function normalizeUniqueToolSpanType(
-  toolName: string,
-  spanType: string,
-  toolBySpanType: Map<string, string>
-): string {
-  const normalizedSpanType = normalizeToolSpanType(spanType, toolName);
-  const conflictingTool = toolBySpanType.get(normalizedSpanType);
-  if (conflictingTool && conflictingTool !== toolName) {
-    throw new Error(
-      `Invalid agentSchema.toolSchemas.${toolName}.spanType: normalized span type "${normalizedSpanType}" conflicts with "${conflictingTool}".`
-    );
-  }
-
-  toolBySpanType.set(normalizedSpanType, toolName);
-  return normalizedSpanType;
-}
-
-function buildToolSpanTypes(
-  toolSchemas: Record<string, ToolSchemaConfig> | undefined
-): Record<string, string> | undefined {
-  if (!toolSchemas) {
-    return undefined;
-  }
-
-  return Object.fromEntries(
-    Object.entries(toolSchemas).map(([toolName, config]) => [toolName, config.spanType])
-  );
-}
-
 function cloneRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return {};
   }
 
   return { ...(value as Record<string, unknown>) };
-}
-
-function stripToolSchemas(
-  baseSchema: Record<string, unknown> | undefined
-): Record<string, unknown> | undefined {
-  if (!baseSchema || typeof baseSchema !== 'object' || Array.isArray(baseSchema)) {
-    return baseSchema;
-  }
-
-  const { toolSchemas: _, ...rest } = baseSchema as Record<string, unknown> & {
-    toolSchemas?: unknown;
-  };
-
-  return rest;
-}
-
-function mergeWithDefaultAgentSchema(
-  baseSchema: Record<string, unknown> | undefined
-): Record<string, unknown> {
-  if (!baseSchema) {
-    return DEFAULT_AI_AGENT_SCHEMA;
-  }
-
-  return {
-    ...DEFAULT_AI_AGENT_SCHEMA,
-    ...baseSchema,
-    span_schemas: {
-      ...cloneRecord(DEFAULT_AI_AGENT_SCHEMA.span_schemas),
-      ...cloneRecord(baseSchema.span_schemas),
-    },
-    span_result_schemas: {
-      ...cloneRecord(DEFAULT_AI_AGENT_SCHEMA.span_result_schemas),
-      ...cloneRecord(baseSchema.span_result_schemas),
-    },
-  };
-}
-
-function normalizeToolSpanType(spanType: string, toolName: string): string {
-  const trimmedSpanType = spanType.trim();
-  if (trimmedSpanType.length === 0) {
-    throw new Error(
-      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty string.`
-    );
-  }
-
-  if (trimmedSpanType.startsWith('ai-sdk:tool:')) {
-    const suffix = trimmedSpanType.slice('ai-sdk:tool:'.length).replace(/^:+/, '');
-    if (suffix.length === 0) {
-      throw new Error(
-        `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty suffix after normalization.`
-      );
-    }
-    return `ai-sdk:tool:${suffix}`;
-  }
-
-  let suffix = trimmedSpanType;
-  if (suffix.startsWith('ai-sdk:')) {
-    suffix = suffix.slice('ai-sdk:'.length);
-  }
-  if (suffix.startsWith('tool:')) {
-    suffix = suffix.slice('tool:'.length);
-  }
-
-  suffix = suffix.replace(/^:+/, '');
-  if (suffix.length === 0) {
-    throw new Error(
-      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty suffix after normalization.`
-    );
-  }
-
-  return `ai-sdk:tool:${suffix}`;
 }

--- a/packages/ai/src/tool-span-contract.ts
+++ b/packages/ai/src/tool-span-contract.ts
@@ -1,0 +1,125 @@
+import type { JsonSchema } from './types.js';
+
+export const GENERIC_OBJECT_SCHEMA = {
+  type: 'object',
+  additionalProperties: true,
+} as const satisfies JsonSchema;
+
+const NORMALIZED_TOOL_OUTPUT_SCHEMA = {
+  anyOf: [
+    { type: 'null' },
+    { type: 'string' },
+    { type: 'number' },
+    { type: 'boolean' },
+    GENERIC_OBJECT_SCHEMA,
+    { type: 'array' },
+  ],
+} as const satisfies JsonSchema;
+
+const TOKEN_USAGE_SCHEMA = {
+  anyOf: [
+    { type: 'null' },
+    {
+      type: 'object',
+      properties: {
+        prompt_tokens: { type: 'number' },
+        completion_tokens: { type: 'number' },
+        total_tokens: { type: 'number' },
+      },
+      required: ['prompt_tokens', 'completion_tokens', 'total_tokens'],
+      additionalProperties: false,
+    },
+  ],
+} as const satisfies JsonSchema;
+
+const ERROR_SCHEMA = {
+  anyOf: [
+    { type: 'null' },
+    {
+      type: 'object',
+      properties: {
+        error_type: { type: 'string' },
+        message: { type: 'string' },
+        stacktrace: { type: 'string' },
+      },
+      required: ['error_type', 'message', 'stacktrace'],
+      additionalProperties: false,
+    },
+  ],
+} as const satisfies JsonSchema;
+
+export function createToolSpanInputs({
+  toolName,
+  toolCallId,
+  input,
+}: {
+  toolName: string;
+  toolCallId?: string;
+  input?: unknown;
+}): Record<string, unknown> {
+  return {
+    'ai.tool.name': toolName,
+    toolName,
+    ...(toolCallId ? { toolCallId } : {}),
+    ...(input !== undefined ? { input } : {}),
+  };
+}
+
+export function createToolSpanOutputs(output: unknown): { output: unknown } {
+  return {
+    output: normalizeToolSpanOutput(output),
+  };
+}
+
+export function buildToolSpanSchema(inputSchema: JsonSchema): JsonSchema {
+  return {
+    type: 'object',
+    properties: {
+      span_id: { type: 'string' },
+      trace_id: { type: 'string' },
+      name: { type: 'string' },
+      status: { type: 'string' },
+      inputs: {
+        type: 'object',
+        properties: {
+          'ai.tool.name': { type: 'string' },
+          toolName: { type: 'string' },
+          toolCallId: { type: 'string' },
+          input: inputSchema,
+        },
+        required: ['ai.tool.name', 'toolName'],
+        additionalProperties: false,
+      },
+      outputs: {
+        type: 'object',
+        properties: {
+          output: NORMALIZED_TOOL_OUTPUT_SCHEMA,
+        },
+        required: ['output'],
+        additionalProperties: false,
+      },
+      metadata: GENERIC_OBJECT_SCHEMA,
+      token_usage: TOKEN_USAGE_SCHEMA,
+      error: ERROR_SCHEMA,
+    },
+    required: ['span_id', 'trace_id', 'name', 'status', 'inputs', 'outputs', 'metadata'],
+    additionalProperties: false,
+  };
+}
+
+function normalizeToolSpanOutput(output: unknown): unknown {
+  if (output === undefined) {
+    return null;
+  }
+
+  if (
+    typeof output === 'object' &&
+    output !== null &&
+    (output as { type?: unknown }).type === 'text' &&
+    typeof (output as { value?: unknown }).value === 'string'
+  ) {
+    return (output as { value: string }).value;
+  }
+
+  return output;
+}

--- a/packages/ai/src/tool-span-contract.ts
+++ b/packages/ai/src/tool-span-contract.ts
@@ -1,4 +1,4 @@
-import type { JsonSchema } from './types.js';
+import type { JsonSchema } from '@prefactor/core';
 
 export const GENERIC_OBJECT_SCHEMA = {
   type: 'object',

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -8,7 +8,7 @@
  * @packageDocumentation
  */
 
-import type { TokenUsage } from '@prefactor/core';
+import type { JsonSchema, TokenUsage, ToolSchemaConfig } from '@prefactor/core';
 
 /**
  * Configuration options for the Prefactor middleware.
@@ -26,27 +26,6 @@ export interface MiddlewareConfig {
    * @default true
    */
   captureTools?: boolean;
-}
-
-/**
- * JSON Schema fragment for a tool's structured input payload.
- */
-export type JsonSchema = Record<string, unknown>;
-
-/**
- * User-defined tool span schema configuration.
- */
-export interface ToolSchemaConfig {
-  /**
-   * Tool-specific schema suffix to emit for this tool.
-   *
-   * Values are normalized under `ai-sdk:tool:*`, so `send-email` becomes
-   * `ai-sdk:tool:send-email`.
-   */
-  spanType: string;
-
-  /** JSON Schema describing the tool call input shape. */
-  inputSchema: JsonSchema;
 }
 
 /**
@@ -106,3 +85,5 @@ export interface ToolCallInfo {
   /** Output from the tool (if available) */
   output?: unknown;
 }
+
+export type { JsonSchema, ToolSchemaConfig };

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -29,6 +29,27 @@ export interface MiddlewareConfig {
 }
 
 /**
+ * JSON Schema fragment for a tool's structured input payload.
+ */
+export type JsonSchema = Record<string, unknown>;
+
+/**
+ * User-defined tool span schema configuration.
+ */
+export interface ToolSchemaConfig {
+  /**
+   * Tool-specific schema suffix to emit for this tool.
+   *
+   * Values are normalized under `ai-sdk:tool:*`, so `send-email` becomes
+   * `ai-sdk:tool:send-email`.
+   */
+  spanType: string;
+
+  /** JSON Schema describing the tool call input shape. */
+  inputSchema: JsonSchema;
+}
+
+/**
  * Data extracted from a generate or stream call.
  * Used internally for building span data.
  */

--- a/packages/ai/tests/init.test.ts
+++ b/packages/ai/tests/init.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
-import { AgentInstanceManager, getClient, init as initCore, Tracer } from '@prefactor/core';
+import {
+  AgentInstanceManager,
+  getClient,
+  init as initCore,
+  type Span,
+  SpanStatus,
+  type SpanType,
+  Tracer,
+} from '@prefactor/core';
+import { init, shutdown, withSpan } from '../src/init.js';
 import { PrefactorAISDK } from '../src/provider.js';
 import { buildToolSpanSchema } from '../src/tool-span-contract.js';
-import { init, shutdown, withSpan } from '../src/init.js';
 
 const baseConfig = {
   transportType: 'http' as const,
@@ -12,6 +20,24 @@ const baseConfig = {
     agentIdentifier: '1.0.0',
   },
 };
+
+function createTestSpan(spanId: string, spanType: string): Span {
+  return {
+    spanId,
+    parentSpanId: null,
+    traceId: `trace-${spanId}`,
+    name: spanId,
+    spanType: spanType as SpanType,
+    startTime: Date.now(),
+    endTime: null,
+    status: SpanStatus.RUNNING,
+    inputs: {},
+    outputs: null,
+    tokenUsage: null,
+    error: null,
+    metadata: {},
+  };
+}
 
 describe('ai init schema registration', () => {
   const originalRegisterSchema = AgentInstanceManager.prototype.registerSchema;
@@ -218,5 +244,52 @@ describe('ai init schema registration', () => {
       startSpanSpy.mockRestore();
       endSpanSpy.mockRestore();
     }
+  });
+
+  test('core provider shutdown finishes started agent instances', async () => {
+    const provider = new PrefactorAISDK();
+    const tracer: Tracer = {
+      startSpan: (options) => createTestSpan(`span-${options.spanType}`, options.spanType),
+      endSpan: () => {},
+      close: async () => {},
+      startAgentInstance: () => {},
+      finishAgentInstance: () => {},
+    } as unknown as Tracer;
+
+    let finishCalls = 0;
+    const agentManager = {
+      registerSchema: () => {},
+      startInstance: () => {},
+      finishInstance: () => {
+        finishCalls += 1;
+      },
+    } as unknown as AgentInstanceManager;
+
+    const middleware = provider.createMiddleware(tracer, agentManager, {
+      transportType: 'http',
+      httpConfig: baseConfig.httpConfig,
+    }) as {
+      wrapGenerate?: (options: {
+        doGenerate: () => Promise<Record<string, unknown>>;
+        model: Record<string, unknown>;
+        params: Record<string, unknown>;
+      }) => Promise<Record<string, unknown>>;
+    };
+
+    await middleware.wrapGenerate?.({
+      doGenerate: async () => ({
+        finishReason: 'stop',
+        text: 'ok',
+      }),
+      model: {
+        provider: 'anthropic.messages',
+        modelId: 'claude-3-haiku-20240307',
+      },
+      params: {},
+    });
+
+    provider.shutdown();
+
+    expect(finishCalls).toBe(1);
   });
 });

--- a/packages/ai/tests/init.test.ts
+++ b/packages/ai/tests/init.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
-import { AgentInstanceManager, Tracer } from '@prefactor/core';
+import { AgentInstanceManager, getClient, init as initCore, Tracer } from '@prefactor/core';
+import { PrefactorAISDK } from '../src/provider.js';
+import { buildToolSpanSchema } from '../src/tool-span-contract.js';
 import { init, shutdown, withSpan } from '../src/init.js';
 
 const baseConfig = {
@@ -27,9 +29,10 @@ describe('ai init schema registration', () => {
   afterEach(async () => {
     AgentInstanceManager.prototype.registerSchema = originalRegisterSchema;
     await shutdown();
+    await getClient()?.shutdown();
   });
 
-  test('registers provided agent schema when configured', () => {
+  test('merges provided agent schema with the default AI schema', () => {
     const customSchema = { type: 'object', title: 'Custom' };
 
     init({
@@ -37,7 +40,22 @@ describe('ai init schema registration', () => {
       httpConfig: { ...baseConfig.httpConfig, agentSchema: customSchema },
     });
 
-    expect(registeredSchemas).toEqual([customSchema]);
+    expect(registeredSchemas).toEqual([
+      {
+        external_identifier: 'ai-sdk-schema',
+        span_schemas: {
+          'ai-sdk:agent': { type: 'object', additionalProperties: true },
+          'ai-sdk:llm': { type: 'object', additionalProperties: true },
+          'ai-sdk:tool': { type: 'object', additionalProperties: true },
+        },
+        span_result_schemas: {
+          'ai-sdk:agent': { type: 'object', additionalProperties: true },
+          'ai-sdk:llm': { type: 'object', additionalProperties: true },
+          'ai-sdk:tool': { type: 'object', additionalProperties: true },
+        },
+        ...customSchema,
+      },
+    ]);
   });
 
   test('registers default schema when only agentIdentifier is set', () => {
@@ -73,6 +91,103 @@ describe('ai init schema registration', () => {
     };
     expect(schema.span_schemas['ai-sdk:chain']).toBeUndefined();
     expect(schema.span_result_schemas['ai-sdk:chain']).toBeUndefined();
+  });
+
+  test('compiles toolSchemas into registered schemas for the core provider path', () => {
+    initCore({
+      provider: new PrefactorAISDK(),
+      httpConfig: {
+        ...baseConfig.httpConfig,
+        agentIdentifier: '1.0.1',
+        agentSchema: {
+          external_identifier: 'ai-sdk-tool-schema-test-v1',
+          span_schemas: {},
+          span_result_schemas: {},
+          toolSchemas: {
+            get_customer_profile: {
+              spanType: 'get-customer-profile',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  customerId: { type: 'string' },
+                },
+                required: ['customerId'],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(registeredSchemas).toHaveLength(1);
+    const schema = registeredSchemas[0] as {
+      span_schemas: Record<string, unknown>;
+      span_result_schemas: Record<string, unknown>;
+      toolSchemas?: unknown;
+    };
+    expect(schema.toolSchemas).toBeUndefined();
+    expect(schema.span_schemas['ai-sdk:tool:get-customer-profile']).toEqual(
+      buildToolSpanSchema({
+        type: 'object',
+        properties: {
+          customerId: { type: 'string' },
+        },
+        required: ['customerId'],
+      })
+    );
+    expect(schema.span_result_schemas['ai-sdk:tool:get-customer-profile']).toEqual({
+      type: 'object',
+      additionalProperties: true,
+    });
+  });
+
+  test('compiles toolSchemas into registered schemas for package init', () => {
+    init({
+      ...baseConfig,
+      httpConfig: {
+        ...baseConfig.httpConfig,
+        agentIdentifier: '1.0.2',
+        agentSchema: {
+          external_identifier: 'ai-sdk-tool-schema-test-v2',
+          span_schemas: {},
+          span_result_schemas: {},
+          toolSchemas: {
+            send_email: {
+              spanType: 'send-email',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  to: { type: 'string' },
+                  subject: { type: 'string' },
+                },
+                required: ['to', 'subject'],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const schema = registeredSchemas[0] as {
+      span_schemas: Record<string, unknown>;
+      span_result_schemas: Record<string, unknown>;
+      toolSchemas?: unknown;
+    };
+    expect(schema.toolSchemas).toBeUndefined();
+    expect(schema.span_schemas['ai-sdk:tool:send-email']).toEqual(
+      buildToolSpanSchema({
+        type: 'object',
+        properties: {
+          to: { type: 'string' },
+          subject: { type: 'string' },
+        },
+        required: ['to', 'subject'],
+      })
+    );
+    expect(schema.span_result_schemas['ai-sdk:tool:send-email']).toEqual({
+      type: 'object',
+      additionalProperties: true,
+    });
   });
 
   test('supports manual spans for custom workflow instrumentation', async () => {

--- a/packages/ai/tests/middleware.test.ts
+++ b/packages/ai/tests/middleware.test.ts
@@ -20,6 +20,11 @@ function createSpan(spanId: string, spanType: string, inputs: Record<string, unk
   };
 }
 
+const agentManagerStub = {
+  startInstance: () => {},
+  finishInstance: () => {},
+} as never;
+
 describe('ai middleware tool instrumentation', () => {
   test('captures tool execute output in tool span payload', async () => {
     const startedSpanTypes: string[] = [];
@@ -98,6 +103,47 @@ describe('ai middleware tool instrumentation', () => {
     expect(Array.isArray(transformed?.tools)).toBe(true);
     const value = await transformed?.tools[0]?.execute({});
     expect(value).toBe('2026-02-11');
+  });
+
+  test('uses configured tool span types for wrapped tools', async () => {
+    const startedSpanTypes: string[] = [];
+
+    const tracer: Tracer = {
+      startSpan: (options) => {
+        startedSpanTypes.push(options.spanType);
+        return createSpan(`span-${startedSpanTypes.length}`, options.spanType, options.inputs);
+      },
+      endSpan: () => {},
+      close: async () => {},
+      startAgentInstance: () => {},
+      finishAgentInstance: () => {},
+    } as unknown as Tracer;
+
+    const middleware = createPrefactorMiddleware(tracer, undefined, {
+      agentManager: agentManagerStub,
+      toolSpanTypes: {
+        get_customer_profile: 'ai-sdk:tool:get-customer-profile',
+      },
+    }) as {
+      transformParams?: (arg: unknown) => Promise<unknown>;
+    };
+
+    const transformed = await middleware.transformParams?.({
+      type: 'generate',
+      params: {
+        tools: {
+          get_customer_profile: {
+            execute: async () => ({ id: 'cust_123' }),
+          },
+        },
+      },
+      model: {},
+    });
+
+    await transformed?.tools?.get_customer_profile?.execute({ customerId: 'cust_123' });
+
+    expect(startedSpanTypes).toContain('ai-sdk:tool:get-customer-profile');
+    expect(startedSpanTypes).not.toContain('ai-sdk:tool');
   });
 
   test('wraps object-map tools in transformParams', async () => {
@@ -232,6 +278,186 @@ describe('ai middleware tool instrumentation', () => {
 
     const toolEnd = ended.find((entry) => entry.span.spanType === `ai-sdk:${SpanType.TOOL}`);
     expect(toolEnd?.options?.outputs).toEqual({ output: '2026-02-11' });
+  });
+
+  test('uses configured tool span types for prompt-derived tool spans', async () => {
+    const startedSpanTypes: string[] = [];
+
+    const tracer: Tracer = {
+      startSpan: (options) => {
+        startedSpanTypes.push(options.spanType);
+        return createSpan(`span-${startedSpanTypes.length}`, options.spanType, options.inputs);
+      },
+      endSpan: () => {},
+      close: async () => {},
+      startAgentInstance: () => {},
+      finishAgentInstance: () => {},
+    } as unknown as Tracer;
+
+    const middleware = createPrefactorMiddleware(tracer, undefined, {
+      agentManager: agentManagerStub,
+      toolSpanTypes: {
+        get_customer_profile: 'ai-sdk:tool:get-customer-profile',
+      },
+    }) as {
+      wrapGenerate?: (arg: unknown) => Promise<unknown>;
+    };
+
+    await middleware.wrapGenerate?.({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'done' }],
+        finishReason: 'stop',
+        usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        warnings: [],
+      }),
+      params: {
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'get_customer_profile',
+                toolCallId: 'call-1',
+                input: { customerId: 'cust_123' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'get_customer_profile',
+                toolCallId: 'call-1',
+                output: { type: 'text', value: '{"id":"cust_123"}' },
+              },
+            ],
+          },
+        ],
+      },
+      model: { provider: 'test', modelId: 'test' },
+    });
+
+    expect(startedSpanTypes).toContain('ai-sdk:tool:get-customer-profile');
+    expect(startedSpanTypes).not.toContain('ai-sdk:tool');
+  });
+
+  test('does not duplicate prompt-derived spans after local tool execution', async () => {
+    const startedSpanTypes: string[] = [];
+
+    const tracer: Tracer = {
+      startSpan: (options) => {
+        startedSpanTypes.push(options.spanType);
+        return createSpan(`span-${startedSpanTypes.length}`, options.spanType, options.inputs);
+      },
+      endSpan: () => {},
+      close: async () => {},
+      startAgentInstance: () => {},
+      finishAgentInstance: () => {},
+    } as unknown as Tracer;
+
+    const middleware = createPrefactorMiddleware(tracer) as {
+      transformParams?: (arg: unknown) => Promise<unknown>;
+      wrapGenerate?: (arg: unknown) => Promise<unknown>;
+    };
+
+    const transformed = await middleware.transformParams?.({
+      type: 'generate',
+      params: {
+        tools: {
+          get_today_date: {
+            execute: async () => '2026-02-11',
+          },
+        },
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'get_today_date',
+                toolCallId: 'call-1',
+                input: {},
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'get_today_date',
+                toolCallId: 'call-1',
+                output: { type: 'text', value: '2026-02-11' },
+              },
+            ],
+          },
+        ],
+      },
+      model: {},
+    });
+
+    await middleware.wrapGenerate?.({
+      doGenerate: async () => {
+        await transformed?.tools?.get_today_date?.execute({}, { toolCallId: 'call-1' });
+        return {
+          content: [{ type: 'text', text: 'done' }],
+          finishReason: 'stop',
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          warnings: [],
+        };
+      },
+      params: transformed,
+      model: { provider: 'test', modelId: 'test' },
+    });
+
+    expect(startedSpanTypes.filter((spanType) => spanType === 'ai-sdk:tool')).toHaveLength(1);
+  });
+
+  test('normalizes failed tool outputs to null for schema compatibility', async () => {
+    const ended: Array<{
+      span: Span;
+      options?: { outputs?: Record<string, unknown>; error?: Error };
+    }> = [];
+
+    const tracer: Tracer = {
+      startSpan: (options) =>
+        createSpan(`span-${options.spanType}`, options.spanType, options.inputs),
+      endSpan: (span, options) => {
+        ended.push({
+          span,
+          options: options as { outputs?: Record<string, unknown>; error?: Error },
+        });
+      },
+      close: async () => {},
+      startAgentInstance: () => {},
+      finishAgentInstance: () => {},
+    } as unknown as Tracer;
+
+    const middleware = createPrefactorMiddleware(tracer) as {
+      transformParams?: (arg: unknown) => Promise<unknown>;
+    };
+
+    const transformed = await middleware.transformParams?.({
+      type: 'generate',
+      params: {
+        tools: {
+          send_email: {
+            execute: async () => {
+              throw new Error('boom');
+            },
+          },
+        },
+      },
+      model: {},
+    });
+
+    await expect(transformed?.tools?.send_email?.execute({})).rejects.toThrow('boom');
+
+    const toolEnd = ended.find((entry) => entry.span.spanType === `ai-sdk:${SpanType.TOOL}`);
+    expect(toolEnd?.options?.outputs).toEqual({ output: null });
+    expect(toolEnd?.options?.error?.message).toBe('boom');
   });
 
   test('does not suppress same toolCallId across separate requests', async () => {

--- a/packages/ai/tests/middleware.test.ts
+++ b/packages/ai/tests/middleware.test.ts
@@ -515,4 +515,235 @@ describe('ai middleware tool instrumentation', () => {
     const toolEnds = ended.filter((entry) => entry.span.spanType === `ai-sdk:${SpanType.TOOL}`);
     expect(toolEnds).toHaveLength(2);
   });
+
+  test('only emits prompt-derived tool spans for the newest trailing tool-result block', async () => {
+    const started: Array<{ spanType: string; inputs: Record<string, unknown> }> = [];
+
+    const tracer: Tracer = {
+      startSpan: (options) => {
+        started.push({ spanType: options.spanType, inputs: options.inputs });
+        return createSpan(`span-${started.length}`, options.spanType, options.inputs);
+      },
+      endSpan: () => {},
+      close: async () => {},
+      startAgentInstance: () => {},
+      finishAgentInstance: () => {},
+    } as unknown as Tracer;
+
+    const middleware = createPrefactorMiddleware(tracer, undefined, {
+      agentManager: agentManagerStub,
+      toolSpanTypes: {
+        get_customer_profile: 'ai-sdk:tool:get-customer-profile',
+        send_email: 'ai-sdk:tool:send-email',
+      },
+    }) as {
+      wrapGenerate?: (arg: unknown) => Promise<unknown>;
+    };
+
+    const baseResult = {
+      content: [{ type: 'text', text: 'done' }],
+      finishReason: 'stop',
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      warnings: [],
+    };
+
+    await middleware.wrapGenerate?.({
+      doGenerate: async () => baseResult,
+      params: {
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'start' }],
+          },
+        ],
+      },
+      model: { provider: 'test', modelId: 'test' },
+    });
+
+    await middleware.wrapGenerate?.({
+      doGenerate: async () => baseResult,
+      params: {
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'start' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'get_customer_profile',
+                toolCallId: 'call-1',
+                input: { customerId: 'cust_123' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'get_customer_profile',
+                toolCallId: 'call-1',
+                output: { type: 'text', value: '{"id":"cust_123"}' },
+              },
+            ],
+          },
+        ],
+      },
+      model: { provider: 'test', modelId: 'test' },
+    });
+
+    await middleware.wrapGenerate?.({
+      doGenerate: async () => baseResult,
+      params: {
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'start' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'get_customer_profile',
+                toolCallId: 'call-1',
+                input: { customerId: 'cust_123' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'get_customer_profile',
+                toolCallId: 'call-1',
+                output: { type: 'text', value: '{"id":"cust_123"}' },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'send_email',
+                toolCallId: 'call-2',
+                input: { to: 'cust_123@example.com', subject: 'done' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'send_email',
+                toolCallId: 'call-2',
+                output: { type: 'text', value: '{"accepted":true}' },
+              },
+            ],
+          },
+        ],
+      },
+      model: { provider: 'test', modelId: 'test' },
+    });
+
+    await middleware.wrapGenerate?.({
+      doGenerate: async () => baseResult,
+      params: {
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'start' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'get_customer_profile',
+                toolCallId: 'call-1',
+                input: { customerId: 'cust_123' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'get_customer_profile',
+                toolCallId: 'call-1',
+                output: { type: 'text', value: '{"id":"cust_123"}' },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'send_email',
+                toolCallId: 'call-2',
+                input: { to: 'cust_123@example.com', subject: 'done' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'send_email',
+                toolCallId: 'call-2',
+                output: { type: 'text', value: '{"accepted":true}' },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'get_current_date',
+                toolCallId: 'call-3',
+                input: {},
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'get_current_date',
+                toolCallId: 'call-3',
+                output: { type: 'text', value: '2026-03-12' },
+              },
+            ],
+          },
+        ],
+      },
+      model: { provider: 'test', modelId: 'test' },
+    });
+
+    const toolStarts = started.filter((entry) => entry.spanType.startsWith('ai-sdk:tool'));
+    expect(toolStarts).toHaveLength(3);
+    expect(
+      toolStarts.filter((entry) => entry.spanType === 'ai-sdk:tool:get-customer-profile')
+    ).toHaveLength(1);
+    expect(toolStarts.filter((entry) => entry.spanType === 'ai-sdk:tool:send-email')).toHaveLength(
+      1
+    );
+    expect(toolStarts.filter((entry) => entry.spanType === 'ai-sdk:tool')).toHaveLength(1);
+    expect(toolStarts.map((entry) => entry.inputs.toolCallId)).toEqual([
+      'call-1',
+      'call-2',
+      'call-3',
+    ]);
+  });
 });

--- a/packages/ai/tests/schema.test.ts
+++ b/packages/ai/tests/schema.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { buildToolSpanSchema, GENERIC_OBJECT_SCHEMA } from '../src/tool-span-contract.js';
+import {
+  DEFAULT_AI_AGENT_SCHEMA,
+  normalizeAgentSchema,
+  resolveToolSpanType,
+} from '../src/schema.js';
+
+describe('ai schema normalization', () => {
+  test('adds tool-specific span schemas and span type mappings', () => {
+    const inputSchema = {
+      type: 'object',
+      properties: {
+        customerId: { type: 'string' },
+      },
+      required: ['customerId'],
+    };
+
+    const normalized = normalizeAgentSchema({
+      external_identifier: 'custom-schema',
+      span_schemas: {},
+      span_result_schemas: {},
+      toolSchemas: {
+        get_customer_profile: {
+          spanType: 'get-customer-profile',
+          inputSchema,
+        },
+      },
+    });
+
+    expect(normalized.toolSpanTypes).toEqual({
+      get_customer_profile: 'ai-sdk:tool:get-customer-profile',
+    });
+    expect(normalized.agentSchema).toEqual({
+      ...DEFAULT_AI_AGENT_SCHEMA,
+      external_identifier: 'custom-schema',
+      span_schemas: {
+        ...DEFAULT_AI_AGENT_SCHEMA.span_schemas,
+        'ai-sdk:tool:get-customer-profile': buildToolSpanSchema(inputSchema),
+      },
+      span_result_schemas: {
+        ...DEFAULT_AI_AGENT_SCHEMA.span_result_schemas,
+        'ai-sdk:tool:get-customer-profile': GENERIC_OBJECT_SCHEMA,
+      },
+    });
+  });
+
+  test('normalizes configured tool span types before lookup', () => {
+    const normalized = normalizeAgentSchema({
+      toolSchemas: {
+        send_email: {
+          spanType: 'ai-sdk:tool:send-email',
+          inputSchema: { type: 'object' },
+        },
+      },
+    });
+
+    expect(resolveToolSpanType('send_email', normalized.toolSpanTypes)).toBe(
+      'ai-sdk:tool:send-email'
+    );
+    expect(resolveToolSpanType('unknown_tool', normalized.toolSpanTypes)).toBe('ai-sdk:tool');
+  });
+
+  test('rejects tool schemas whose normalized span types collide', () => {
+    expect(() =>
+      normalizeAgentSchema({
+        toolSchemas: {
+          get_customer_profile: {
+            spanType: 'get-customer-profile',
+            inputSchema: { type: 'object' },
+          },
+          lookup_customer: {
+            spanType: 'ai-sdk:tool:get-customer-profile',
+            inputSchema: { type: 'object' },
+          },
+        },
+      })
+    ).toThrow('conflicts with "get_customer_profile"');
+  });
+});

--- a/packages/ai/tests/schema.test.ts
+++ b/packages/ai/tests/schema.test.ts
@@ -1,12 +1,19 @@
-import { describe, expect, test } from 'bun:test';
-import { buildToolSpanSchema, GENERIC_OBJECT_SCHEMA } from '../src/tool-span-contract.js';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import {
   DEFAULT_AI_AGENT_SCHEMA,
   normalizeAgentSchema,
   resolveToolSpanType,
 } from '../src/schema.js';
+import { buildToolSpanSchema, GENERIC_OBJECT_SCHEMA } from '../src/tool-span-contract.js';
 
 describe('ai schema normalization', () => {
+  let warnSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+    warnSpy = undefined;
+  });
+
   test('adds tool-specific span schemas and span type mappings', () => {
     const inputSchema = {
       type: 'object',
@@ -61,20 +68,52 @@ describe('ai schema normalization', () => {
     expect(resolveToolSpanType('unknown_tool', normalized.toolSpanTypes)).toBe('ai-sdk:tool');
   });
 
-  test('rejects tool schemas whose normalized span types collide', () => {
-    expect(() =>
-      normalizeAgentSchema({
-        toolSchemas: {
-          get_customer_profile: {
-            spanType: 'get-customer-profile',
-            inputSchema: { type: 'object' },
-          },
-          lookup_customer: {
-            spanType: 'ai-sdk:tool:get-customer-profile',
-            inputSchema: { type: 'object' },
-          },
+  test('warns and skips tool schemas whose normalized span types collide', () => {
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+    const normalized = normalizeAgentSchema({
+      toolSchemas: {
+        get_customer_profile: {
+          spanType: 'get-customer-profile',
+          inputSchema: { type: 'object' },
         },
-      })
-    ).toThrow('conflicts with "get_customer_profile"');
+        lookup_customer: {
+          spanType: 'ai-sdk:tool:get-customer-profile',
+          inputSchema: { type: 'object' },
+        },
+      },
+    });
+
+    expect(normalized.toolSpanTypes).toEqual({
+      get_customer_profile: 'ai-sdk:tool:get-customer-profile',
+    });
+    expect(normalized.agentSchema).toEqual({
+      ...DEFAULT_AI_AGENT_SCHEMA,
+      span_schemas: {
+        ...DEFAULT_AI_AGENT_SCHEMA.span_schemas,
+        'ai-sdk:tool:get-customer-profile': buildToolSpanSchema({ type: 'object' }),
+      },
+      span_result_schemas: {
+        ...DEFAULT_AI_AGENT_SCHEMA.span_result_schemas,
+        'ai-sdk:tool:get-customer-profile': GENERIC_OBJECT_SCHEMA,
+      },
+    });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test('warns and ignores invalid toolSchemas config without breaking normalization', () => {
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+    const normalized = normalizeAgentSchema({
+      external_identifier: 'custom-schema',
+      toolSchemas: 'bad-config' as unknown as Record<string, unknown>,
+    });
+
+    expect(normalized.toolSpanTypes).toBeUndefined();
+    expect(normalized.agentSchema).toEqual({
+      ...DEFAULT_AI_AGENT_SCHEMA,
+      external_identifier: 'custom-schema',
+    });
+    expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prefactor/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Framework-agnostic observability primitives for Prefactor",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -48,6 +48,15 @@ export interface PrefactorProvider {
    */
   shutdown?: () => void | Promise<void>;
   /**
+   * Normalizes a user- or provider-authored agent schema before core registers it.
+   *
+   * @param agentSchema - Authored agent schema configuration.
+   * @returns Normalized schema, or `undefined` to leave the input unchanged.
+   */
+  normalizeAgentSchema?: (
+    agentSchema: Record<string, unknown>
+  ) => Record<string, unknown> | undefined;
+  /**
    * Provides a default agent schema when a user does not supply one.
    *
    * @returns Agent schema object, or `undefined` when no default is available.
@@ -178,6 +187,21 @@ export function init(options: PrefactorOptions): PrefactorClient {
         agentSchema: providerSchema,
       },
     };
+  }
+
+  if (finalConfig.httpConfig?.agentSchema) {
+    const normalizedSchema = options.provider.normalizeAgentSchema?.(
+      finalConfig.httpConfig.agentSchema
+    );
+    if (normalizedSchema) {
+      finalConfig = {
+        ...finalConfig,
+        httpConfig: {
+          ...finalConfig.httpConfig,
+          agentSchema: normalizedSchema,
+        },
+      };
+    }
   }
 
   const core = createCore(finalConfig);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -29,7 +29,7 @@ export type MiddlewareLike = unknown;
 /**
  * Provider integration contract for Prefactor SDK clients.
  */
-export interface PrefactorProvider {
+export interface PrefactorProvider<TMiddleware = MiddlewareLike> {
   /**
    * Creates provider middleware bound to the core runtime services.
    *
@@ -38,11 +38,7 @@ export interface PrefactorProvider {
    * @param config - Resolved SDK configuration.
    * @returns Provider middleware consumed by upstream frameworks.
    */
-  createMiddleware(
-    tracer: Tracer,
-    agentManager: AgentInstanceManager,
-    config: Config
-  ): MiddlewareLike;
+  createMiddleware(tracer: Tracer, agentManager: AgentInstanceManager, config: Config): TMiddleware;
   /**
    * Optional provider-level cleanup hook invoked during client shutdown.
    */
@@ -64,13 +60,13 @@ export interface PrefactorProvider {
   getDefaultAgentSchema?: () => Record<string, unknown> | undefined;
 }
 
-let prefactorClient: PrefactorClient | null = null;
+let prefactorClient: PrefactorClient<MiddlewareLike> | null = null;
 let prefactorInitKey: string | null = null;
 
-export class PrefactorClient {
+export class PrefactorClient<TMiddleware = MiddlewareLike> {
   private readonly core: CoreRuntime;
-  private readonly middleware: MiddlewareLike;
-  private readonly provider: PrefactorProvider;
+  private readonly middleware: TMiddleware;
+  private readonly provider: PrefactorProvider<TMiddleware>;
 
   /**
    * Creates a Prefactor client bound to a runtime and provider middleware.
@@ -79,7 +75,11 @@ export class PrefactorClient {
    * @param middleware - Provider middleware returned by the integration.
    * @param provider - Provider used to construct the client.
    */
-  constructor(core: CoreRuntime, middleware: MiddlewareLike, provider: PrefactorProvider) {
+  constructor(
+    core: CoreRuntime,
+    middleware: TMiddleware,
+    provider: PrefactorProvider<TMiddleware>
+  ) {
     this.core = core;
     this.middleware = middleware;
     this.provider = provider;
@@ -99,7 +99,7 @@ export class PrefactorClient {
    *
    * @returns Provider middleware object.
    */
-  getMiddleware(): MiddlewareLike {
+  getMiddleware(): TMiddleware {
     return this.middleware;
   }
 
@@ -144,9 +144,9 @@ export class PrefactorClient {
 /**
  * Options for initializing the global Prefactor client.
  */
-export interface PrefactorOptions {
+export interface PrefactorOptions<TMiddleware = MiddlewareLike> {
   /** Provider integration used to create middleware and defaults. */
-  provider: PrefactorProvider;
+  provider: PrefactorProvider<TMiddleware>;
   /** Optional HTTP configuration overrides for the runtime config. */
   httpConfig?: Config['httpConfig'];
 }
@@ -159,7 +159,9 @@ export interface PrefactorOptions {
  * @param options - Initialization options.
  * @returns Global Prefactor client instance.
  */
-export function init(options: PrefactorOptions): PrefactorClient {
+export function init<TMiddleware = MiddlewareLike>(
+  options: PrefactorOptions<TMiddleware>
+): PrefactorClient<TMiddleware> {
   const nextInitKey = buildInitKey(options);
 
   if (prefactorClient) {
@@ -170,7 +172,7 @@ export function init(options: PrefactorOptions): PrefactorClient {
       );
     }
 
-    return prefactorClient;
+    return prefactorClient as PrefactorClient<TMiddleware>;
   }
 
   configureLogging();
@@ -213,10 +215,10 @@ export function init(options: PrefactorOptions): PrefactorClient {
 
   const middleware = options.provider.createMiddleware(core.tracer, core.agentManager, finalConfig);
 
-  prefactorClient = new PrefactorClient(core, middleware, options.provider);
+  prefactorClient = new PrefactorClient<TMiddleware>(core, middleware, options.provider);
   prefactorInitKey = nextInitKey;
 
-  return prefactorClient;
+  return prefactorClient as PrefactorClient<TMiddleware>;
 }
 
 /**
@@ -224,8 +226,8 @@ export function init(options: PrefactorOptions): PrefactorClient {
  *
  * @returns Active global client or `null`.
  */
-export function getClient(): PrefactorClient | null {
-  return prefactorClient;
+export function getClient<TMiddleware = MiddlewareLike>(): PrefactorClient<TMiddleware> | null {
+  return prefactorClient as PrefactorClient<TMiddleware> | null;
 }
 
 function buildInitKey(options: PrefactorOptions): string {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -226,9 +226,9 @@ export function init<TMiddleware = MiddlewareLike>(
  *
  * @returns Active global client or `null`.
  */
-export function getClient<TMiddleware = MiddlewareLike>(): PrefactorClient<TMiddleware> | null {
-  return prefactorClient as PrefactorClient<TMiddleware> | null;
-}
+ export function getClient(): PrefactorClient<MiddlewareLike> | null {
+   return prefactorClient
+ }
 
 function buildInitKey(options: PrefactorOptions): string {
   const providerType = options.provider.constructor?.name ?? 'anonymous-provider';

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -226,9 +226,9 @@ export function init<TMiddleware = MiddlewareLike>(
  *
  * @returns Active global client or `null`.
  */
- export function getClient(): PrefactorClient<MiddlewareLike> | null {
-   return prefactorClient
- }
+export function getClient(): PrefactorClient<MiddlewareLike> | null {
+  return prefactorClient;
+}
 
 function buildInitKey(options: PrefactorOptions): string {
   const providerType = options.provider.constructor?.name ?? 'anonymous-provider';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,12 @@ export {
 } from './config.js';
 export { type CoreRuntime, createCore } from './create-core.js';
 export { registerShutdownHandler, shutdown } from './lifecycle.js';
+export {
+  type JsonSchema,
+  normalizeAgentToolSchemas,
+  resolveMappedSpanType,
+  type ToolSchemaConfig,
+} from './tool-schema.js';
 export { SpanContext } from './tracing/context.js';
 export {
   createSpanTypePrefixer,

--- a/packages/core/src/tool-schema.ts
+++ b/packages/core/src/tool-schema.ts
@@ -1,0 +1,269 @@
+import { getLogger } from './utils/logging.js';
+
+export type JsonSchema = Record<string, unknown>;
+
+export interface ToolSchemaConfig {
+  spanType: string;
+  inputSchema: JsonSchema;
+}
+
+export interface NormalizedAgentToolSchemas {
+  agentSchema: Record<string, unknown>;
+  toolSchemas?: Record<string, ToolSchemaConfig>;
+  toolSpanTypes?: Record<string, string>;
+}
+
+const logger = getLogger('tool-schema');
+
+export function normalizeAgentToolSchemas(
+  agentSchema: Record<string, unknown> | undefined,
+  {
+    defaultAgentSchema,
+    providerName,
+  }: {
+    defaultAgentSchema: Record<string, unknown>;
+    providerName: string;
+  }
+): NormalizedAgentToolSchemas {
+  const toolSchemas = extractToolSchemas(agentSchema, providerName);
+  return {
+    agentSchema: mergeWithDefaultAgentSchema(stripToolSchemas(agentSchema), defaultAgentSchema),
+    toolSchemas,
+    toolSpanTypes: buildToolSpanTypes(toolSchemas),
+  };
+}
+
+export function resolveMappedSpanType(
+  toolName: string,
+  toolSpanTypes: Record<string, string> | undefined,
+  defaultSpanType: string
+): string {
+  return toolSpanTypes?.[toolName] ?? defaultSpanType;
+}
+
+function extractToolSchemas(
+  agentSchema: Record<string, unknown> | undefined,
+  providerName: string
+): Record<string, ToolSchemaConfig> | undefined {
+  const rawToolSchemas = getRawToolSchemas(agentSchema);
+  if (!rawToolSchemas) {
+    return undefined;
+  }
+
+  const toolSchemas: Record<string, ToolSchemaConfig> = {};
+  const toolBySpanType = new Map<string, string>();
+  for (const [toolName, rawConfig] of Object.entries(rawToolSchemas)) {
+    const parsedToolSchema = parseToolSchemaConfig(
+      toolName,
+      rawConfig,
+      providerName,
+      toolBySpanType
+    );
+    if (!parsedToolSchema) {
+      continue;
+    }
+
+    toolSchemas[toolName] = parsedToolSchema;
+  }
+
+  return Object.keys(toolSchemas).length > 0 ? toolSchemas : undefined;
+}
+
+function getRawToolSchemas(
+  agentSchema: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!agentSchema || typeof agentSchema !== 'object' || Array.isArray(agentSchema)) {
+    return undefined;
+  }
+
+  const rawToolSchemas = (agentSchema as { toolSchemas?: unknown }).toolSchemas;
+  if (rawToolSchemas === undefined) {
+    return undefined;
+  }
+
+  if (!rawToolSchemas || typeof rawToolSchemas !== 'object' || Array.isArray(rawToolSchemas)) {
+    logger.warn('Ignoring invalid agentSchema.toolSchemas: expected an object keyed by tool name.');
+    return undefined;
+  }
+
+  return rawToolSchemas as Record<string, unknown>;
+}
+
+function parseToolSchemaConfig(
+  toolName: string,
+  rawConfig: unknown,
+  providerName: string,
+  toolBySpanType: Map<string, string>
+): ToolSchemaConfig | undefined {
+  if (!rawConfig || typeof rawConfig !== 'object' || Array.isArray(rawConfig)) {
+    logger.warn(
+      `Invalid agentSchema.toolSchemas.${toolName}: expected an object with spanType and inputSchema.`
+    );
+    return undefined;
+  }
+
+  const config = rawConfig as {
+    spanType?: unknown;
+    inputSchema?: unknown;
+  };
+
+  if (typeof config.spanType !== 'string') {
+    logger.warn(
+      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty string.`
+    );
+    return undefined;
+  }
+
+  const inputSchema = assertValidInputSchema(toolName, config.inputSchema);
+  if (!inputSchema) {
+    return undefined;
+  }
+
+  const normalizedSpanType = normalizeUniqueToolSpanType(
+    toolName,
+    config.spanType,
+    providerName,
+    toolBySpanType
+  );
+  if (!normalizedSpanType) {
+    return undefined;
+  }
+
+  return {
+    spanType: normalizedSpanType,
+    inputSchema,
+  };
+}
+
+function assertValidInputSchema(toolName: string, inputSchema: unknown): JsonSchema | undefined {
+  if (!inputSchema || typeof inputSchema !== 'object' || Array.isArray(inputSchema)) {
+    logger.warn(`Invalid agentSchema.toolSchemas.${toolName}.inputSchema: expected an object.`);
+    return undefined;
+  }
+
+  return inputSchema as JsonSchema;
+}
+
+function normalizeUniqueToolSpanType(
+  toolName: string,
+  spanType: string,
+  providerName: string,
+  toolBySpanType: Map<string, string>
+): string | undefined {
+  const normalizedSpanType = normalizeToolSpanType(spanType, toolName, providerName);
+  if (!normalizedSpanType) {
+    return undefined;
+  }
+
+  const conflictingTool = toolBySpanType.get(normalizedSpanType);
+  if (conflictingTool && conflictingTool !== toolName) {
+    logger.warn(
+      `Invalid agentSchema.toolSchemas.${toolName}.spanType: normalized span type "${normalizedSpanType}" conflicts with "${conflictingTool}".`
+    );
+    return undefined;
+  }
+
+  toolBySpanType.set(normalizedSpanType, toolName);
+  return normalizedSpanType;
+}
+
+function buildToolSpanTypes(
+  toolSchemas: Record<string, ToolSchemaConfig> | undefined
+): Record<string, string> | undefined {
+  if (!toolSchemas) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(toolSchemas).map(([toolName, config]) => [toolName, config.spanType])
+  );
+}
+
+function cloneRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return { ...(value as Record<string, unknown>) };
+}
+
+function stripToolSchemas(
+  baseSchema: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!baseSchema || typeof baseSchema !== 'object' || Array.isArray(baseSchema)) {
+    return baseSchema;
+  }
+
+  const { toolSchemas: _, ...rest } = baseSchema as Record<string, unknown> & {
+    toolSchemas?: unknown;
+  };
+
+  return rest;
+}
+
+function mergeWithDefaultAgentSchema(
+  baseSchema: Record<string, unknown> | undefined,
+  defaultAgentSchema: Record<string, unknown>
+): Record<string, unknown> {
+  if (!baseSchema) {
+    return defaultAgentSchema;
+  }
+
+  return {
+    ...defaultAgentSchema,
+    ...baseSchema,
+    span_schemas: {
+      ...cloneRecord(defaultAgentSchema.span_schemas),
+      ...cloneRecord(baseSchema.span_schemas),
+    },
+    span_result_schemas: {
+      ...cloneRecord(defaultAgentSchema.span_result_schemas),
+      ...cloneRecord(baseSchema.span_result_schemas),
+    },
+  };
+}
+
+function normalizeToolSpanType(
+  spanType: string,
+  toolName: string,
+  providerName: string
+): string | undefined {
+  const trimmedSpanType = spanType.trim();
+  if (trimmedSpanType.length === 0) {
+    logger.warn(
+      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty string.`
+    );
+    return undefined;
+  }
+
+  const providerToolPrefix = `${providerName}:tool:`;
+  if (trimmedSpanType.startsWith(providerToolPrefix)) {
+    const suffix = trimmedSpanType.slice(providerToolPrefix.length).replace(/^:+/, '');
+    if (suffix.length === 0) {
+      logger.warn(
+        `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty suffix after normalization.`
+      );
+      return undefined;
+    }
+
+    return `${providerName}:tool:${suffix}`;
+  }
+
+  let suffix = trimmedSpanType;
+  if (suffix.startsWith(`${providerName}:`)) {
+    suffix = suffix.slice(`${providerName}:`.length);
+  }
+  if (suffix.startsWith('tool:')) {
+    suffix = suffix.slice('tool:'.length);
+  }
+
+  suffix = suffix.replace(/^:+/, '');
+  if (suffix.length === 0) {
+    logger.warn(
+      `Invalid agentSchema.toolSchemas.${toolName}.spanType: expected a non-empty suffix after normalization.`
+    );
+    return undefined;
+  }
+
+  return `${providerName}:tool:${suffix}`;
+}


### PR DESCRIPTION
Closes pre-219

Exposes per-tool span schema support for the Vercel AI SDK integration while moving the shared tool-schema normalisation into core.
Also fixed some dx in relation to type casting middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New example demonstrating per-tool schemas and end-to-end tool orchestration.
  * Tool-level spans are emitted with configurable span types for richer observability.

* **Improvements**
  * Expanded public typings and generics for safer SDK integration.
  * Added agent/tool schema normalization and span-contract utilities for more robust configuration.
  * Improved init/shutdown and lifecycle handling.

* **Tests**
  * Comprehensive tests for schema normalization, middleware tool instrumentation, and lifecycle shutdown.

* **Chores**
  * Updated ignore patterns to exclude local CLI artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->