### PR TITLE
PRE-253: Add data risk APIs to TypeScript SDK core and OpenClaw

### DIFF
--- a/packages/openclaw-prefactor-plugin/src/agent.ts
+++ b/packages/openclaw-prefactor-plugin/src/agent.ts
@@ -31,6 +31,43 @@ interface AgentVersionForRegister {
   description: string;
 }
 
+// Risk configuration types
+export type ActionProfile = {
+  create_data: 'unknown' | 'allowed' | 'disallowed';
+  read_data: 'unknown' | 'allowed' | 'disallowed';
+  update_data: 'unknown' | 'allowed' | 'disallowed';
+  destroy_data: 'unknown' | 'allowed' | 'disallowed';
+  financial_transactions: 'unknown' | 'allowed' | 'disallowed';
+  external_communication: 'unknown' | 'allowed' | 'disallowed';
+};
+
+export type DataCategories = {
+  classification: 'unknown' | 'public' | 'internal' | 'confidential' | 'restricted' | 'secret';
+  personal_identifiers: 'unknown' | 'included' | 'excluded';
+  contact_information: 'unknown' | 'included' | 'excluded';
+  financial_information: 'unknown' | 'included' | 'excluded';
+  health_and_medical: 'unknown' | 'included' | 'excluded';
+  criminal_justice: 'unknown' | 'included' | 'excluded';
+  authentication_and_secrets: 'unknown' | 'included' | 'excluded';
+  organisational_confidential: 'unknown' | 'included' | 'excluded';
+  minors_data: 'unknown' | 'included' | 'excluded';
+  location_and_tracking: 'unknown' | 'included' | 'excluded';
+  behavioural_and_inferred: 'unknown' | 'included' | 'excluded';
+  gdpr_racial_or_ethnic_origin: 'unknown' | 'included' | 'excluded';
+  gdpr_political_opinions: 'unknown' | 'included' | 'excluded';
+  gdpr_religious_or_philosophical_beliefs: 'unknown' | 'included' | 'excluded';
+  gdpr_trade_union_membership: 'unknown' | 'included' | 'excluded';
+  gdpr_genetic_data: 'unknown' | 'included' | 'excluded';
+  gdpr_biometric_for_identification: 'unknown' | 'included' | 'excluded';
+  gdpr_sex_life_or_sexual_orientation: 'unknown' | 'included' | 'excluded';
+};
+
+export type DataRisk = {
+  action_profile: ActionProfile;
+  params_data_categories: DataCategories;
+  result_data_categories: DataCategories;
+};
+
 // Agent schema version info for registration
 interface SpanTypeSchema {
   name: string;
@@ -45,6 +82,7 @@ interface SpanTypeSchema {
   template?: string | null;
   result_template?: string | null;
   description?: string;
+  data_risk?: DataRisk;
 }
 
 interface AgentSchemaVersionForRegister extends Record<string, unknown> {
@@ -149,6 +187,7 @@ export interface AgentConfig {
   pluginVersion?: string;
   userAgentVersion?: string;
   userAgentName?: string;
+  spanTypeRiskConfigs?: Record<string, DataRisk>;
 }
 
 /**
@@ -214,6 +253,7 @@ export class Agent {
       description: `${agentName} — OpenClaw ${openclawVersion} with Prefactor Plugin ${pluginVersion}`,
     } satisfies AgentVersionForRegister;
 
+    const spanTypeRiskConfigs = config.spanTypeRiskConfigs;
     this.agentSchemaVersion = {
       external_identifier: `plugin-${pluginVersion}`,
       span_type_schemas: [
@@ -227,6 +267,7 @@ export class Agent {
               raw: { type: 'object', description: 'Raw OpenClaw message context' },
             },
           },
+          data_risk: spanTypeRiskConfigs?.['openclaw:user_message'],
         },
         // Generic fallback for unknown tools
         {
@@ -247,6 +288,7 @@ export class Agent {
               isError: { type: 'boolean', description: 'Whether tool failed' },
             },
           },
+          data_risk: spanTypeRiskConfigs?.['openclaw:tool_call'],
         },
         // Supported tool-specific schemas
         ...this.buildSupportedToolSchemas(),
@@ -269,6 +311,7 @@ export class Agent {
               text: { type: 'string', description: 'Assistant response text' },
             },
           },
+          data_risk: spanTypeRiskConfigs?.['openclaw:assistant_response'],
         },
         {
           name: 'openclaw:agent_run',
@@ -280,6 +323,7 @@ export class Agent {
               raw: { type: 'object', description: 'Raw OpenClaw context' },
             },
           },
+          data_risk: spanTypeRiskConfigs?.['openclaw:agent_run'],
         },
         {
           name: 'openclaw:session',
@@ -291,6 +335,7 @@ export class Agent {
               createdAt: { type: 'string', description: 'Session created timestamp' },
             },
           },
+          data_risk: spanTypeRiskConfigs?.['openclaw:session'],
         },
         {
           name: 'openclaw:user_interaction',
@@ -302,6 +347,7 @@ export class Agent {
               startedAt: { type: 'string', description: 'User interaction timestamp' },
             },
           },
+          data_risk: spanTypeRiskConfigs?.['openclaw:user_interaction'],
         },
         {
           name: 'openclaw:agent_thinking',
@@ -323,6 +369,7 @@ export class Agent {
               thinking: { type: 'string', description: 'Agent thinking content' },
             },
           },
+          data_risk: spanTypeRiskConfigs?.['openclaw:agent_thinking'],
         },
       ],
     };

--- a/packages/openclaw-prefactor-plugin/src/agent.ts
+++ b/packages/openclaw-prefactor-plugin/src/agent.ts
@@ -11,6 +11,7 @@ import {
   type HttpTransportConfig,
 } from '@prefactor/core';
 import packageJson from '../package.json' with { type: 'json' };
+import { defaultSpanTypeRiskConfigs } from './data-risk-config.js';
 import type { Logger } from './logger.js';
 import { getAllSupportedToolDefinitions, normalizeToolName } from './tool-definitions.js';
 import { buildToolSpanSchema } from './tool-span-contract.js';
@@ -253,7 +254,7 @@ export class Agent {
       description: `${agentName} — OpenClaw ${openclawVersion} with Prefactor Plugin ${pluginVersion}`,
     } satisfies AgentVersionForRegister;
 
-    const spanTypeRiskConfigs = config.spanTypeRiskConfigs;
+    const spanTypeRiskConfigs = config.spanTypeRiskConfigs ?? defaultSpanTypeRiskConfigs;
     this.agentSchemaVersion = {
       external_identifier: `plugin-${pluginVersion}`,
       span_type_schemas: [
@@ -291,7 +292,7 @@ export class Agent {
           data_risk: spanTypeRiskConfigs?.['openclaw:tool_call'],
         },
         // Supported tool-specific schemas
-        ...this.buildSupportedToolSchemas(),
+        ...this.buildSupportedToolSchemas(spanTypeRiskConfigs),
         {
           name: 'openclaw:assistant_response',
           description: 'Assistant response generation span',
@@ -415,7 +416,9 @@ export class Agent {
    * Builds span type schemas for supported tools (read, write, edit, exec, web_search, web_fetch, browser).
    * Each tool gets its own schema with proper input validation and tool-specific templates.
    */
-  private buildSupportedToolSchemas(): SpanTypeSchema[] {
+  private buildSupportedToolSchemas(
+    spanTypeRiskConfigs: Record<string, DataRisk>
+  ): SpanTypeSchema[] {
     const supportedTools = getAllSupportedToolDefinitions();
     const schemas: SpanTypeSchema[] = [];
 
@@ -448,6 +451,7 @@ export class Agent {
             output: { type: 'string' },
           },
         },
+        data_risk: spanTypeRiskConfigs[spanType],
       });
     }
 

--- a/packages/openclaw-prefactor-plugin/src/data-risk-config.ts
+++ b/packages/openclaw-prefactor-plugin/src/data-risk-config.ts
@@ -1,0 +1,350 @@
+/**
+ * Data risk configuration for OpenClaw span types.
+ *
+ * Defines default risk profiles for each span type based on the operations they perform
+ * and the categories of sensitive data they may handle. These profiles are used for
+ * compliance tracking and data governance.
+ *
+ * @module @prefactor/openclaw-prefactor-plugin/data-risk
+ */
+
+import type { DataRisk } from './agent.js';
+
+/**
+ * Helper to create a DataCategories object with all fields set to a specific value.
+ * Useful for creating consistent category sets.
+ */
+function createDataCategories(
+  classification: DataRisk['params_data_categories']['classification'],
+  value: 'unknown' | 'included' | 'excluded' = 'unknown'
+): DataRisk['params_data_categories'] {
+  return {
+    classification,
+    personal_identifiers: value,
+    contact_information: value,
+    financial_information: value,
+    health_and_medical: value,
+    criminal_justice: value,
+    authentication_and_secrets: value,
+    organisational_confidential: value,
+    minors_data: value,
+    location_and_tracking: value,
+    behavioural_and_inferred: value,
+    gdpr_racial_or_ethnic_origin: value,
+    gdpr_political_opinions: value,
+    gdpr_religious_or_philosophical_beliefs: value,
+    gdpr_trade_union_membership: value,
+    gdpr_genetic_data: value,
+    gdpr_biometric_for_identification: value,
+    gdpr_sex_life_or_sexual_orientation: value,
+  };
+}
+
+/**
+ * Default risk profile for openclaw:user_message span.
+ * User messages may contain any type of data including organizational confidential information.
+ */
+export const userMessageRisk: DataRisk = {
+  action_profile: {
+    create_data: 'unknown',
+    read_data: 'unknown',
+    update_data: 'unknown',
+    destroy_data: 'unknown',
+    financial_transactions: 'disallowed',
+    external_communication: 'unknown',
+  },
+  params_data_categories: createDataCategories('confidential', 'unknown'),
+  result_data_categories: createDataCategories('confidential', 'unknown'),
+};
+
+/**
+ * Default risk profile for openclaw:agent_run span.
+ * Agent runs orchestrate operations but don't directly handle data mutations.
+ */
+export const agentRunRisk: DataRisk = {
+  action_profile: {
+    create_data: 'unknown',
+    read_data: 'unknown',
+    update_data: 'unknown',
+    destroy_data: 'unknown',
+    financial_transactions: 'disallowed',
+    external_communication: 'unknown',
+  },
+  params_data_categories: createDataCategories('internal', 'unknown'),
+  result_data_categories: createDataCategories('internal', 'unknown'),
+};
+
+/**
+ * Default risk profile for openclaw:agent_thinking span.
+ * Thinking spans contain reasoning that may reference organizational confidential data.
+ */
+export const agentThinkingRisk: DataRisk = {
+  action_profile: {
+    create_data: 'allowed',
+    read_data: 'unknown',
+    update_data: 'unknown',
+    destroy_data: 'unknown',
+    financial_transactions: 'disallowed',
+    external_communication: 'unknown',
+  },
+  params_data_categories: createDataCategories('confidential', 'unknown'),
+  result_data_categories: createDataCategories('confidential', 'unknown'),
+};
+
+/**
+ * Default risk profile for openclaw:assistant_response span.
+ * Assistant responses may contain organizational confidential information from context.
+ */
+export const assistantResponseRisk: DataRisk = {
+  action_profile: {
+    create_data: 'allowed',
+    read_data: 'unknown',
+    update_data: 'unknown',
+    destroy_data: 'unknown',
+    financial_transactions: 'disallowed',
+    external_communication: 'unknown',
+  },
+  params_data_categories: createDataCategories('confidential', 'unknown'),
+  result_data_categories: createDataCategories('internal', 'unknown'),
+};
+
+/**
+ * Default risk profile for openclaw:session span.
+ * Session spans track lifecycle but contain minimal data.
+ */
+export const sessionRisk: DataRisk = {
+  action_profile: {
+    create_data: 'allowed',
+    read_data: 'unknown',
+    update_data: 'unknown',
+    destroy_data: 'unknown',
+    financial_transactions: 'disallowed',
+    external_communication: 'unknown',
+  },
+  params_data_categories: createDataCategories('internal', 'unknown'),
+  result_data_categories: createDataCategories('internal', 'unknown'),
+};
+
+/**
+ * Default risk profile for openclaw:user_interaction span.
+ * User interactions may involve organizational confidential data.
+ */
+export const userInteractionRisk: DataRisk = {
+  action_profile: {
+    create_data: 'unknown',
+    read_data: 'unknown',
+    update_data: 'unknown',
+    destroy_data: 'unknown',
+    financial_transactions: 'disallowed',
+    external_communication: 'unknown',
+  },
+  params_data_categories: createDataCategories('confidential', 'unknown'),
+  result_data_categories: createDataCategories('confidential', 'unknown'),
+};
+
+/**
+ * Default risk profile for openclaw:tool span (generic fallback).
+ * Generic tool calls have unknown risk until specific tool is identified.
+ */
+export const toolRisk: DataRisk = {
+  action_profile: {
+    create_data: 'unknown',
+    read_data: 'unknown',
+    update_data: 'unknown',
+    destroy_data: 'unknown',
+    financial_transactions: 'disallowed',
+    external_communication: 'unknown',
+  },
+  params_data_categories: createDataCategories('unknown', 'unknown'),
+  result_data_categories: createDataCategories('unknown', 'unknown'),
+};
+
+/**
+ * Default risk profile for openclaw:tool:read span.
+ * Read operations access filesystem data which may include organizational confidential info and secrets.
+ */
+export const toolReadRisk: DataRisk = {
+  action_profile: {
+    create_data: 'disallowed',
+    read_data: 'allowed',
+    update_data: 'disallowed',
+    destroy_data: 'disallowed',
+    financial_transactions: 'disallowed',
+    external_communication: 'disallowed',
+  },
+  params_data_categories: {
+    ...createDataCategories('confidential', 'excluded'),
+    authentication_and_secrets: 'included',
+    organisational_confidential: 'included',
+  },
+  result_data_categories: {
+    ...createDataCategories('confidential', 'excluded'),
+    authentication_and_secrets: 'included',
+    organisational_confidential: 'included',
+  },
+};
+
+/**
+ * Default risk profile for openclaw:tool:write span.
+ * Write operations create data which may include organizational confidential info.
+ */
+export const toolWriteRisk: DataRisk = {
+  action_profile: {
+    create_data: 'allowed',
+    read_data: 'disallowed',
+    update_data: 'disallowed',
+    destroy_data: 'disallowed',
+    financial_transactions: 'disallowed',
+    external_communication: 'disallowed',
+  },
+  params_data_categories: {
+    ...createDataCategories('confidential', 'excluded'),
+    authentication_and_secrets: 'unknown',
+    organisational_confidential: 'included',
+  },
+  result_data_categories: {
+    ...createDataCategories('confidential', 'excluded'),
+    authentication_and_secrets: 'unknown',
+    organisational_confidential: 'included',
+  },
+};
+
+/**
+ * Default risk profile for openclaw:tool:edit span.
+ * Edit operations modify data which may include organizational confidential info and secrets.
+ */
+export const toolEditRisk: DataRisk = {
+  action_profile: {
+    create_data: 'disallowed',
+    read_data: 'disallowed',
+    update_data: 'allowed',
+    destroy_data: 'disallowed',
+    financial_transactions: 'disallowed',
+    external_communication: 'disallowed',
+  },
+  params_data_categories: {
+    ...createDataCategories('confidential', 'excluded'),
+    authentication_and_secrets: 'included',
+    organisational_confidential: 'included',
+  },
+  result_data_categories: {
+    ...createDataCategories('confidential', 'excluded'),
+    authentication_and_secrets: 'included',
+    organisational_confidential: 'included',
+  },
+};
+
+/**
+ * Default risk profile for openclaw:tool:exec span.
+ * Shell execution is high-risk - can access secrets and execute arbitrary commands.
+ */
+export const toolExecRisk: DataRisk = {
+  action_profile: {
+    create_data: 'unknown',
+    read_data: 'allowed',
+    update_data: 'unknown',
+    destroy_data: 'unknown',
+    financial_transactions: 'disallowed',
+    external_communication: 'disallowed',
+  },
+  params_data_categories: {
+    ...createDataCategories('restricted', 'excluded'),
+    authentication_and_secrets: 'included',
+    organisational_confidential: 'included',
+  },
+  result_data_categories: {
+    ...createDataCategories('restricted', 'excluded'),
+    authentication_and_secrets: 'included',
+    organisational_confidential: 'included',
+  },
+};
+
+/**
+ * Default risk profile for openclaw:tool:web_search span.
+ * Web search sends queries to external services but doesn't typically include sensitive data.
+ */
+export const toolWebSearchRisk: DataRisk = {
+  action_profile: {
+    create_data: 'disallowed',
+    read_data: 'disallowed',
+    update_data: 'disallowed',
+    destroy_data: 'disallowed',
+    financial_transactions: 'disallowed',
+    external_communication: 'allowed',
+  },
+  params_data_categories: createDataCategories('public', 'excluded'),
+  result_data_categories: createDataCategories('public', 'excluded'),
+};
+
+/**
+ * Default risk profile for openclaw:tool:web_fetch span.
+ * Web fetch retrieves public content from external URLs.
+ */
+export const toolWebFetchRisk: DataRisk = {
+  action_profile: {
+    create_data: 'disallowed',
+    read_data: 'disallowed',
+    update_data: 'disallowed',
+    destroy_data: 'disallowed',
+    financial_transactions: 'disallowed',
+    external_communication: 'allowed',
+  },
+  params_data_categories: createDataCategories('public', 'excluded'),
+  result_data_categories: createDataCategories('public', 'excluded'),
+};
+
+/**
+ * Default risk profile for openclaw:tool:browser span.
+ * Browser automation interacts with external web services.
+ */
+export const toolBrowserRisk: DataRisk = {
+  action_profile: {
+    create_data: 'disallowed',
+    read_data: 'disallowed',
+    update_data: 'disallowed',
+    destroy_data: 'disallowed',
+    financial_transactions: 'disallowed',
+    external_communication: 'allowed',
+  },
+  params_data_categories: createDataCategories('public', 'excluded'),
+  result_data_categories: createDataCategories('public', 'excluded'),
+};
+
+/**
+ * Complete default risk configuration for all OpenClaw span types.
+ * This configuration is used when registering the agent schema version.
+ */
+export const defaultSpanTypeRiskConfigs: Record<string, DataRisk> = {
+  'openclaw:user_message': userMessageRisk,
+  'openclaw:agent_run': agentRunRisk,
+  'openclaw:agent_thinking': agentThinkingRisk,
+  'openclaw:assistant_response': assistantResponseRisk,
+  'openclaw:session': sessionRisk,
+  'openclaw:user_interaction': userInteractionRisk,
+  'openclaw:tool': toolRisk,
+  'openclaw:tool:read': toolReadRisk,
+  'openclaw:tool:write': toolWriteRisk,
+  'openclaw:tool:edit': toolEditRisk,
+  'openclaw:tool:exec': toolExecRisk,
+  'openclaw:tool:web_search': toolWebSearchRisk,
+  'openclaw:tool:web_fetch': toolWebFetchRisk,
+  'openclaw:tool:browser': toolBrowserRisk,
+};
+
+/**
+ * Creates a merged risk configuration by combining default configs with user-provided overrides.
+ * User overrides take precedence over defaults.
+ *
+ * @param userConfigs - User-provided risk configurations to merge with defaults
+ * @returns Merged risk configuration
+ */
+export function createRiskConfig(userConfigs?: Record<string, DataRisk>): Record<string, DataRisk> {
+  if (!userConfigs) {
+    return { ...defaultSpanTypeRiskConfigs };
+  }
+
+  return {
+    ...defaultSpanTypeRiskConfigs,
+    ...userConfigs,
+  };
+}

--- a/packages/openclaw-prefactor-plugin/src/index.ts
+++ b/packages/openclaw-prefactor-plugin/src/index.ts
@@ -645,11 +645,30 @@ export default function register(api: OpenClawPluginApi) {
 // Re-export types for TypeDoc visibility
 export type { ActionProfile, Agent, AgentConfig, DataCategories, DataRisk } from './agent.js';
 export { createAgent } from './agent.js';
+
+// Data risk configuration exports
+export {
+  agentRunRisk,
+  agentThinkingRisk,
+  assistantResponseRisk,
+  createRiskConfig,
+  defaultSpanTypeRiskConfigs,
+  sessionRisk,
+  toolBrowserRisk,
+  toolEditRisk,
+  toolExecRisk,
+  toolReadRisk,
+  toolRisk,
+  toolWebFetchRisk,
+  toolWebSearchRisk,
+  toolWriteRisk,
+  userInteractionRisk,
+  userMessageRisk,
+} from './data-risk-config.js';
 export type { Logger, LogLevel } from './logger.js';
 export { createLogger } from './logger.js';
 export type { SessionStateManager } from './session-state.js';
 export { createSessionStateManager } from './session-state.js';
-
 // Tool schema exports
 export type { ToolDefinition } from './tool-definitions.js';
 export {

--- a/packages/openclaw-prefactor-plugin/src/index.ts
+++ b/packages/openclaw-prefactor-plugin/src/index.ts
@@ -643,7 +643,7 @@ export default function register(api: OpenClawPluginApi) {
 }
 
 // Re-export types for TypeDoc visibility
-export type { Agent, AgentConfig } from './agent.js';
+export type { ActionProfile, Agent, AgentConfig, DataCategories, DataRisk } from './agent.js';
 export { createAgent } from './agent.js';
 export type { Logger, LogLevel } from './logger.js';
 export { createLogger } from './logger.js';


### PR DESCRIPTION
Add ActionProfile, DataCategories, and DataRisk types to support data risk configuration per span type. Update AgentConfig to accept spanTypeRiskConfigs and merge them into the agent schema version during registration. All 7 OpenClaw span types now support optional risk configuration.

Exported types: ActionProfile, DataCategories, DataRisk