### PR TITLE
Fix musl release smoke runner setup

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -82,39 +82,52 @@ jobs:
             artifact: prefactor-linux-x64.tar.gz
             archive: prefactor-linux-x64.tar.gz
             extracted_bin: prefactor
+            requires_musl: false
           - os: ubuntu-latest
             artifact: prefactor-linux-x64-musl.tar.gz
             archive: prefactor-linux-x64-musl.tar.gz
             extracted_bin: prefactor
+            requires_musl: true
           - os: ubuntu-24.04-arm
             artifact: prefactor-linux-arm64.tar.gz
             archive: prefactor-linux-arm64.tar.gz
             extracted_bin: prefactor
+            requires_musl: false
           - os: ubuntu-24.04-arm
             artifact: prefactor-linux-arm64-musl.tar.gz
             archive: prefactor-linux-arm64-musl.tar.gz
             extracted_bin: prefactor
+            requires_musl: true
           - os: macos-latest
             artifact: prefactor-darwin-arm64.tar.gz
             archive: prefactor-darwin-arm64.tar.gz
             extracted_bin: prefactor
+            requires_musl: false
           - os: macos-15-intel
             artifact: prefactor-darwin-x64.tar.gz
             archive: prefactor-darwin-x64.tar.gz
             extracted_bin: prefactor
+            requires_musl: false
           - os: windows-latest
             artifact: prefactor-windows-x64.zip
             archive: prefactor-windows-x64.zip
             extracted_bin: prefactor.exe
+            requires_musl: false
           - os: windows-11-arm
             artifact: prefactor-windows-arm64.zip
             archive: prefactor-windows-arm64.zip
             extracted_bin: prefactor.exe
+            requires_musl: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.artifact }}
+      - name: Install musl runtime
+        if: runner.os != 'Windows' && matrix.requires_musl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl
       - name: Run smoke test (unix)
         if: runner.os != 'Windows'
         run: |


### PR DESCRIPTION
## What changed
- restore the musl smoke-test matrix entries in the CLI release workflow
- install the Ubuntu `musl` runtime package before running musl-linked binaries in those smoke jobs

## Why
The `Release CLI Binaries` workflow on `main` failed after PR #38 because the new musl smoke jobs tried to execute musl-linked binaries on Ubuntu runners without the musl loader present. The failing symptom in Actions was:

```text
smoke/prefactor: cannot execute: required file not found
```

This change keeps musl smoke coverage in place and makes those jobs runnable on the existing hosted runners.

## Impact
- musl release artifacts remain built and smoke-tested
- release publishing is no longer blocked by missing musl runtime support on Ubuntu runners
- no changes to the non-musl smoke jobs

## Validation
- YAML parse for `.github/workflows/release-cli.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal testing infrastructure for release builds across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->