### PR TITLE
[PRE-280] Add tests for CLI update command

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -123,13 +123,33 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-      - name: Install musl runtime
-        if: runner.os != 'Windows' && matrix.requires_musl
+      - name: Run smoke test (linux musl)
+        if: runner.os == 'Linux' && matrix.requires_musl
+        env:
+          ARCHIVE: ${{ matrix.archive }}
+          EXTRACTED_BIN: ${{ matrix.extracted_bin }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y musl
+          docker run --rm \
+            -e HOME=/tmp/prefactor-home \
+            -e ARCHIVE \
+            -e EXTRACTED_BIN \
+            -v "$PWD:/work" \
+            -w /work \
+            alpine:3.22 \
+            sh -euxc '
+              apk add --no-cache ca-certificates libgcc libstdc++
+              rm -rf "$HOME" smoke
+              mkdir -p "$HOME" smoke
+              tar -xzf "$ARCHIVE" -C smoke
+              chmod +x "smoke/$EXTRACTED_BIN"
+              "smoke/$EXTRACTED_BIN" --version
+              "smoke/$EXTRACTED_BIN" install --channel stable
+              "$HOME/.prefactor/bin/prefactor" doctor
+              "$HOME/.prefactor/bin/prefactor" update
+              "$HOME/.prefactor/bin/prefactor" doctor
+            '
       - name: Run smoke test (unix)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && !matrix.requires_musl
         run: |
           export HOME="${RUNNER_TEMP}/prefactor-home"
           rm -rf "$HOME" && mkdir -p "$HOME"
@@ -138,6 +158,8 @@ jobs:
           chmod +x smoke/${{ matrix.extracted_bin }}
           smoke/${{ matrix.extracted_bin }} --version
           smoke/${{ matrix.extracted_bin }} install --channel stable
+          "$HOME/.prefactor/bin/prefactor" doctor
+          "$HOME/.prefactor/bin/prefactor" update
           "$HOME/.prefactor/bin/prefactor" doctor
       - name: Run smoke test (windows)
         if: runner.os == 'Windows'
@@ -151,6 +173,12 @@ jobs:
           .\smoke\${{ matrix.extracted_bin }} --version
           .\smoke\${{ matrix.extracted_bin }} install --channel stable
           & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" doctor
+          $output = & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" update 2>&1
+          Write-Output $output
+          if ($output -notmatch "Update started") {
+            Write-Error "Expected update start message not found"
+            exit 1
+          }
 
   release:
     runs-on: ubuntu-latest
@@ -169,7 +197,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist/cli
-          sha256sum *.tar.gz *.zip > SHA256SUMS
+          sha256sum -- *.tar.gz *.zip > SHA256SUMS
       - name: Create versioned release
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -174,6 +174,11 @@ jobs:
           .\smoke\${{ matrix.extracted_bin }} install --channel stable
           & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" doctor
           $output = & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" update 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output $output
+            Write-Error "prefactor update failed with exit code $LASTEXITCODE"
+            exit 1
+          }
           Write-Output $output
           if ($output -notmatch "Update started") {
             Write-Error "Expected update start message not found"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,7 +1,7 @@
 name: Release CLI Binaries
 
 on:
-  pull_request:
+  push:
     branches: [main]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,9 +1,14 @@
 name: Release CLI Binaries
 
 on:
-  push:
+  pull_request:
     branches: [main]
-    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable CLI version to release. Must match packages/cli/package.json.
+        required: true
+        type: string
 
 jobs:
   build:
@@ -128,50 +133,103 @@ jobs:
         env:
           ARCHIVE: ${{ matrix.archive }}
           EXTRACTED_BIN: ${{ matrix.extracted_bin }}
+          SMOKE_TAG: smoke-${{ github.sha }}
         run: |
           docker run --rm \
             -e HOME=/tmp/prefactor-home \
             -e ARCHIVE \
             -e EXTRACTED_BIN \
+            -e SMOKE_TAG \
             -v "$PWD:/work" \
             -w /work \
             alpine:3.22 \
             sh -euxc '
-              apk add --no-cache ca-certificates libgcc libstdc++
-              rm -rf "$HOME" smoke
+              apk add --no-cache ca-certificates libgcc libstdc++ python3
+              release_root=/tmp/prefactor-release
+              release_dir="$release_root/releases/download/$SMOKE_TAG"
+              rm -rf "$HOME" smoke "$release_root"
               mkdir -p "$HOME" smoke
+              mkdir -p "$release_dir"
+              cp "$ARCHIVE" "$release_dir/$ARCHIVE"
+              (
+                cd "$release_dir"
+                sha256sum -- "$ARCHIVE" > SHA256SUMS
+              )
+              python3 -m http.server 8765 --bind 127.0.0.1 --directory "$release_root" >/tmp/prefactor-release-server.log 2>&1 &
+              server_pid=$!
+              trap "kill $server_pid" EXIT
+              export PREFACTOR_RELEASE_BASE_URL="http://127.0.0.1:8765/releases/download"
+              export PREFACTOR_RELEASE_LATEST_BASE_URL="$PREFACTOR_RELEASE_BASE_URL/$SMOKE_TAG"
               tar -xzf "$ARCHIVE" -C smoke
               chmod +x "smoke/$EXTRACTED_BIN"
               "smoke/$EXTRACTED_BIN" --version
               "smoke/$EXTRACTED_BIN" install --channel stable
               "$HOME/.prefactor/bin/prefactor" doctor
               "$HOME/.prefactor/bin/prefactor" update
-              "$HOME/.prefactor/bin/prefactor" doctor
+              "$HOME/.prefactor/bin/prefactor" doctor | tee /tmp/prefactor-doctor.log
+              grep -q "resolvedTag: $SMOKE_TAG" /tmp/prefactor-doctor.log
             '
       - name: Run smoke test (unix)
         if: runner.os != 'Windows' && !matrix.requires_musl
+        env:
+          ARCHIVE: ${{ matrix.archive }}
+          EXTRACTED_BIN: ${{ matrix.extracted_bin }}
+          SMOKE_TAG: smoke-${{ github.sha }}
         run: |
           export HOME="${RUNNER_TEMP}/prefactor-home"
-          rm -rf "$HOME" && mkdir -p "$HOME"
+          release_root="${RUNNER_TEMP}/prefactor-release"
+          release_dir="$release_root/releases/download/$SMOKE_TAG"
+          rm -rf "$HOME" "$release_root" && mkdir -p "$HOME" "$release_dir"
+          cp "$ARCHIVE" "$release_dir/$ARCHIVE"
+          checksum="$(
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum -- "$ARCHIVE" | awk '{ print $1 }'
+            else
+              shasum -a 256 "$ARCHIVE" | awk '{ print $1 }'
+            fi
+          )"
+          printf '%s  %s\n' "$checksum" "$ARCHIVE" > "$release_dir/SHA256SUMS"
+          python3 -m http.server 8765 --bind 127.0.0.1 --directory "$release_root" >"${RUNNER_TEMP}/prefactor-release-server.log" 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid"' EXIT
+          export PREFACTOR_RELEASE_BASE_URL="http://127.0.0.1:8765/releases/download"
+          export PREFACTOR_RELEASE_LATEST_BASE_URL="$PREFACTOR_RELEASE_BASE_URL/$SMOKE_TAG"
           rm -rf smoke && mkdir smoke
-          tar -xzf ${{ matrix.archive }} -C smoke
-          chmod +x smoke/${{ matrix.extracted_bin }}
-          smoke/${{ matrix.extracted_bin }} --version
-          smoke/${{ matrix.extracted_bin }} install --channel stable
+          tar -xzf "$ARCHIVE" -C smoke
+          chmod +x "smoke/$EXTRACTED_BIN"
+          "smoke/$EXTRACTED_BIN" --version
+          "smoke/$EXTRACTED_BIN" install --channel stable
           "$HOME/.prefactor/bin/prefactor" doctor
           "$HOME/.prefactor/bin/prefactor" update
-          "$HOME/.prefactor/bin/prefactor" doctor
+          "$HOME/.prefactor/bin/prefactor" doctor | tee "${RUNNER_TEMP}/prefactor-doctor.log"
+          grep -q "resolvedTag: $SMOKE_TAG" "${RUNNER_TEMP}/prefactor-doctor.log"
       - name: Run smoke test (windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          ARCHIVE: ${{ matrix.archive }}
+          EXTRACTED_BIN: ${{ matrix.extracted_bin }}
+          SMOKE_TAG: smoke-${{ github.sha }}
         run: |
           $env:USERPROFILE = Join-Path $env:RUNNER_TEMP 'prefactor-home'
           New-Item -ItemType Directory -Path $env:USERPROFILE -Force | Out-Null
+          $releaseRoot = Join-Path $env:RUNNER_TEMP 'prefactor-release'
+          $releaseDir = Join-Path $releaseRoot "releases\download\$env:SMOKE_TAG"
+          Remove-Item -LiteralPath $releaseRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
+          $archiveCopy = Join-Path $releaseDir $env:ARCHIVE
+          Copy-Item -LiteralPath $env:ARCHIVE -Destination $archiveCopy
+          $checksum = (Get-FileHash -Path $archiveCopy -Algorithm SHA256).Hash.ToLowerInvariant()
+          Set-Content -LiteralPath (Join-Path $releaseDir 'SHA256SUMS') -Value "$checksum  $env:ARCHIVE"
+          $server = Start-Process -FilePath python -ArgumentList @('-m', 'http.server', '8765', '--bind', '127.0.0.1', '--directory', $releaseRoot) -PassThru -WindowStyle Hidden
+          Start-Sleep -Seconds 1
+          $env:PREFACTOR_RELEASE_BASE_URL = 'http://127.0.0.1:8765/releases/download'
+          $env:PREFACTOR_RELEASE_LATEST_BASE_URL = "$env:PREFACTOR_RELEASE_BASE_URL/$env:SMOKE_TAG"
           Remove-Item -LiteralPath smoke -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Path smoke | Out-Null
-          Expand-Archive -LiteralPath ${{ matrix.archive }} -DestinationPath smoke -Force
-          .\smoke\${{ matrix.extracted_bin }} --version
-          .\smoke\${{ matrix.extracted_bin }} install --channel stable
+          Expand-Archive -LiteralPath $env:ARCHIVE -DestinationPath smoke -Force
+          & ".\smoke\$env:EXTRACTED_BIN" --version
+          & ".\smoke\$env:EXTRACTED_BIN" install --channel stable
           & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" doctor
           $output = & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" update 2>&1 | Out-String
           if ($LASTEXITCODE -ne 0) {
@@ -184,17 +242,67 @@ jobs:
             Write-Error "Expected update start message not found"
             exit 1
           }
+          $doctorOutput = ''
+          for ($attempt = 0; $attempt -lt 60; $attempt += 1) {
+            Start-Sleep -Milliseconds 500
+            $doctorOutput = (& "$env:USERPROFILE\.prefactor\bin\prefactor.exe" doctor 2>&1 | Out-String)
+            if ($doctorOutput -match "resolvedTag: $env:SMOKE_TAG") {
+              Write-Output $doctorOutput
+              Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+              exit 0
+            }
+          }
+          Write-Output $doctorOutput
+          Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+          Write-Error "Expected installed CLI to update to $env:SMOKE_TAG"
+          exit 1
 
   release:
     runs-on: ubuntu-latest
     needs: [build, smoke-test]
     concurrency:
-      group: ${{ github.ref_type != 'tag' && format('{0}-canary', github.repository) || format('{0}-{1}', github.workflow, github.ref) }}
-      cancel-in-progress: ${{ github.ref_type != 'tag' }}
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      group: ${{ format('{0}-stable-release', github.repository) }}
+      cancel-in-progress: false
+    if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+      - name: Prepare stable release
+        id: release
+        run: |
+          version="${{ inputs.version }}"
+          case "$version" in
+            v*) tag="$version" ;;
+            *) tag="v$version" ;;
+          esac
+
+          if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid stable release version: $version" >&2
+            exit 1
+          fi
+
+          package_version="$(node -p "require('./packages/cli/package.json').version")"
+          if [ "$tag" != "v$package_version" ]; then
+            echo "Release tag $tag does not match @prefactor/cli package version v$package_version." >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists." >&2
+            exit 1
+          fi
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists." >&2
+            exit 1
+          fi
+
+          git tag "$tag" "$GITHUB_SHA"
+          git push origin "refs/tags/$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v4
         with:
           path: dist/cli
@@ -203,23 +311,11 @@ jobs:
         run: |
           cd dist/cli
           sha256sum -- *.tar.gz *.zip > SHA256SUMS
-      - name: Create versioned release
-        if: github.ref_type == 'tag'
+      - name: Create stable release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          prerelease: false
-          files: dist/cli/*
-      - name: Delete canary tag
-        if: github.ref_type != 'tag'
-        run: gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/canary || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create canary release
-        if: github.ref_type != 'tag'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: canary
+          tag_name: ${{ steps.release.outputs.tag }}
           target_commitish: ${{ github.sha }}
-          prerelease: true
+          prerelease: false
+          draft: false
           files: dist/cli/*

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -173,7 +173,7 @@ jobs:
           .\smoke\${{ matrix.extracted_bin }} --version
           .\smoke\${{ matrix.extracted_bin }} install --channel stable
           & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" doctor
-          $output = & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" update 2>&1
+          $output = & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" update 2>&1 | Out-String
           Write-Output $output
           if ($output -notmatch "Update started") {
             Write-Error "Expected update start message not found"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "bun run scripts/build.ts",
     "docs:typedoc": "typedoc --options typedoc.json",
     "versions:check": "bun run scripts/generate-versions.ts --check",
+    "release:cli:stable": "bun run scripts/release-cli-stable.ts",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "typecheck": "tsc --build",

--- a/packages/cli/src/install/installer.ts
+++ b/packages/cli/src/install/installer.ts
@@ -460,7 +460,7 @@ function buildChildInstallArgs(
   childBinaryPath: string,
   spec: ReleaseSpec,
   resolvedTag: string,
-  currentPid: number
+  waitForPid: number | undefined
 ): string[] {
   return [
     'install',
@@ -470,8 +470,7 @@ function buildChildInstallArgs(
     resolvedTag,
     '--asset-name',
     spec.assetName,
-    '--wait-for-pid',
-    String(currentPid),
+    ...(waitForPid !== undefined ? ['--wait-for-pid', String(waitForPid)] : []),
     ...(spec.channel === 'pinned' && spec.requestedVersion
       ? ['--version', spec.requestedVersion]
       : ['--channel', spec.channel]),
@@ -485,9 +484,8 @@ async function runChildInstaller(
   deps: LifecycleCommandDeps,
   platform: PlatformInfo['platform']
 ): Promise<void> {
-  const args = buildChildInstallArgs(childBinaryPath, spec, resolvedTag, process.pid);
-
   if (platform === 'windows') {
+    const args = buildChildInstallArgs(childBinaryPath, spec, resolvedTag, process.pid);
     await new Promise<void>((resolvePromise, reject) => {
       const child = deps.spawnProcess(childBinaryPath, args, {
         detached: true,
@@ -503,6 +501,7 @@ async function runChildInstaller(
     return;
   }
 
+  const args = buildChildInstallArgs(childBinaryPath, spec, resolvedTag, undefined);
   await new Promise<void>((resolvePromise, reject) => {
     const child = deps.spawnProcess(childBinaryPath, args, {
       stdio: 'inherit',

--- a/packages/cli/tests/install.test.ts
+++ b/packages/cli/tests/install.test.ts
@@ -268,7 +268,6 @@ describe('install helpers', () => {
       )
     );
 
-    expect(readFileSync(childLog, 'utf8')).not.toContain('--wait-for-pid');
   });
 
   test('readInstallState rejects invalid persisted channel values', async () => {

--- a/packages/cli/tests/install.test.ts
+++ b/packages/cli/tests/install.test.ts
@@ -267,7 +267,6 @@ describe('install helpers', () => {
         tempRoot
       )
     );
-
   });
 
   test('readInstallState rejects invalid persisted channel values', async () => {

--- a/packages/cli/tests/install.test.ts
+++ b/packages/cli/tests/install.test.ts
@@ -268,7 +268,7 @@ describe('install helpers', () => {
       )
     );
 
-    expect(readFileSync(childLog, 'utf8')).toContain('--wait-for-pid');
+    expect(readFileSync(childLog, 'utf8')).not.toContain('--wait-for-pid');
   });
 
   test('readInstallState rejects invalid persisted channel values', async () => {

--- a/scripts/release-cli-stable.ts
+++ b/scripts/release-cli-stable.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from 'node:child_process';
+import packageJson from '../packages/cli/package.json';
+
+function usage(exitCode: 0 | 1): never {
+  const stream = exitCode === 0 ? console.log : console.error;
+  stream('Usage: bun scripts/release-cli-stable.ts [version]');
+  stream('');
+  stream('Examples:');
+  stream(`  bun scripts/release-cli-stable.ts`);
+  stream(`  bun scripts/release-cli-stable.ts ${packageJson.version}`);
+  process.exit(exitCode);
+}
+
+function normalizeVersion(version: string): string {
+  const trimmed = version.trim();
+  if (!trimmed) {
+    usage(1);
+  }
+
+  const normalized = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+  if (!/^\d+\.\d+\.\d+$/.test(normalized)) {
+    throw new Error(`Invalid version '${version}'. Expected semver like 0.0.5 or v0.0.5.`);
+  }
+
+  return normalized;
+}
+
+const args = process.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  usage(0);
+}
+if (args.length > 1) {
+  usage(1);
+}
+
+const version = normalizeVersion(args[0] ?? packageJson.version);
+if (version !== packageJson.version) {
+  throw new Error(
+    `Requested version ${version} does not match @prefactor/cli package version ${packageJson.version}.`
+  );
+}
+
+const result = spawnSync(
+  'gh',
+  ['workflow', 'run', 'release-cli.yml', '--ref', 'main', '--field', `version=${version}`],
+  {
+    stdio: 'inherit',
+  }
+);
+
+if (result.error) {
+  throw result.error;
+}
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+console.log(`Dispatched stable CLI release workflow for v${version}.`);
+console.log('Track it with: gh run list --workflow release-cli.yml --limit 1');


### PR DESCRIPTION
Closes pre-280

The update command on Unix spawned a child installer with --wait-for-pid pointing to the parent process, then synchronously awaited the child's exit. The child, in turn, polled for the parent PID to exit before proceeding. This caused a deadlock that would hang until the 25s timeout.

- buildChildInstallArgs now only emits --wait-for-pid on Windows, where file locking requires the detached child to wait for the parent to exit.
- On Unix the child installer runs synchronously without waiting.
- Updated unit test to assert --wait-for-pid is absent on Unix.
- Added prefactor update to release-cli.yml smoke tests for all 8 platform targets (linux x64/arm64 glibc/musl, darwin x64/arm64, windows x64/arm64).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Child installer no longer waits for an unnecessary process on non‑Windows systems, preventing install hangs.

* **Chores**
  * Release flow reworked to require a validated stable-version dispatch and publish only stable (non‑prerelease) artifacts; added a helper to trigger this flow.
  * Checksum generation hardened to avoid glob-related issues.

* **Tests**
  * Smoke tests strengthened: musl scenario runs containerized; Linux and Windows tests now serve artifacts locally and verify resolved release tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->