### PR TITLE
[PRE-347] pre 347 add support for agent_context on cli

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "@prefactor/core": "^0.3.0",
+        "@prefactor/core": "^0.4.0",
         "ai": "^4.0.0 || ^5.0.0 || ^6.0.0",
       },
     },
@@ -52,7 +52,7 @@
       },
       "peerDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
-        "@prefactor/core": "^0.3.0",
+        "@prefactor/core": "^0.4.0",
       },
     },
     "packages/cli": {
@@ -88,7 +88,7 @@
         "@prefactor/pfid": "^0.1.0",
       },
       "peerDependencies": {
-        "@prefactor/core": "^0.3.0",
+        "@prefactor/core": "^0.4.0",
         "langchain": "^1.0.0",
       },
     },
@@ -100,7 +100,7 @@
       },
       "peerDependencies": {
         "@livekit/agents": "^1.0.0",
-        "@prefactor/core": "^0.3.0",
+        "@prefactor/core": "^0.4.0",
       },
     },
     "packages/openclaw-prefactor-plugin": {
@@ -115,7 +115,7 @@
         "typescript": "^5.0.0",
       },
       "peerDependencies": {
-        "@prefactor/core": "^0.3.0",
+        "@prefactor/core": "^0.4.0",
       },
     },
   },

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -33,7 +33,7 @@
     "@prefactor/pfid": "^0.1.0"
   },
   "peerDependencies": {
-    "@prefactor/core": ">=0.4.0",
+    "@prefactor/core": "^0.4.0",
     "ai": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -33,7 +33,7 @@
     "@prefactor/pfid": "^0.1.0"
   },
   "peerDependencies": {
-    "@prefactor/core": "^0.4.1",
+    "@prefactor/core": ">=0.4.0",
     "ai": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {

--- a/packages/claude/package.json
+++ b/packages/claude/package.json
@@ -32,7 +32,7 @@
     "@prefactor/pfid": "^0.1.0"
   },
   "peerDependencies": {
-    "@prefactor/core": ">=0.4.0",
+    "@prefactor/core": "^0.4.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.0"
   },
   "devDependencies": {

--- a/packages/claude/package.json
+++ b/packages/claude/package.json
@@ -32,7 +32,7 @@
     "@prefactor/pfid": "^0.1.0"
   },
   "peerDependencies": {
-    "@prefactor/core": "^0.4.1",
+    "@prefactor/core": ">=0.4.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.0"
   },
   "devDependencies": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -73,7 +73,7 @@ npm install @prefactor/cli
 prefactor login
 ```
 
-This opens your browser to the Prefactor login page. After authenticating, copy your API token and paste it into the prompt. Your credentials are saved automatically to the `default` profile.
+This opens your browser to the Prefactor login page. After authenticating, copy your API token and paste it into the prompt. Your credentials are saved to the `default` profile when no default exists.
 
 2. Verify access:
 
@@ -109,7 +109,7 @@ Environment fallback is supported when no default profile is configured:
 
 ## Command Groups
 
-- `login`: authenticate and save credentials to the default profile
+- `login`: authenticate and save credentials to the matching profile
 - `profiles`: add, list, remove
 - `accounts`: list, retrieve, update
 - `environments`: list, retrieve, create, update, delete
@@ -117,7 +117,7 @@ Environment fallback is supported when no default profile is configured:
 - `agent_deployments`: list, retrieve, create, update, delete
 - `agent_versions`: list, retrieve, create
 - `agent_schema_versions`: list, retrieve, create
-- `agent_instances`: list, retrieve, register, start, finish
+- `agent_instances`: list, retrieve, agent_context, register, start, finish
 - `agent_spans`: list, create, finish, create_test_spans
 - `api_tokens`: list, retrieve, create, suspend, activate, revoke, delete
 - `admin_users`: list, retrieve

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -73,7 +73,7 @@ npm install @prefactor/cli
 prefactor login
 ```
 
-This opens your browser to the Prefactor login page. After authenticating, copy your API token and paste it into the prompt. Your credentials are saved to the `default` profile when no default exists.
+This opens your browser to the Prefactor login page. After authenticating, copy your API token and paste it into the prompt. Your credentials are saved automatically to the `default` profile.
 
 2. Verify access:
 
@@ -109,7 +109,7 @@ Environment fallback is supported when no default profile is configured:
 
 ## Command Groups
 
-- `login`: authenticate and save credentials to the matching profile
+- `login`: authenticate and save credentials to the default profile
 - `profiles`: add, list, remove
 - `accounts`: list, retrieve, update
 - `environments`: list, retrieve, create, update, delete

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prefactor/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Prefactor command-line interface",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/cli/src/commands/agent-instances.ts
+++ b/packages/cli/src/commands/agent-instances.ts
@@ -1,3 +1,4 @@
+import { writeFile } from 'node:fs/promises';
 import type { Command } from 'commander';
 import { AgentInstanceClient } from '../clients/agent-instance.js';
 import {
@@ -31,6 +32,27 @@ export function registerAgentInstancesCommands(program: Command): void {
     .action(function (this: Command, id: string) {
       return executeAuthed(this, async (apiClient) => {
         const result = await apiClient.request(`/agent_instance/${id}`, { method: 'GET' });
+        printJson(result);
+      });
+    });
+
+  agentInstances
+    .command('agent_context <id>')
+    .description('Export debugging context JSON for an agent instance')
+    .option('--output <path>', 'Write context JSON body to this file')
+    .action(function (this: Command, id: string, options: { output?: string }) {
+      return executeAuthed(this, async (apiClient) => {
+        const result = await apiClient.request<Record<string, unknown>>(
+          `/agent_instance/${id}/agent_context`,
+          { method: 'GET' }
+        );
+
+        if (options.output) {
+          const body = extractAgentContextBody(result);
+          await writeFile(options.output, `${JSON.stringify(body, null, 2)}\n`, 'utf8');
+          return;
+        }
+
         printJson(result);
       });
     });
@@ -146,4 +168,18 @@ export function registerAgentInstancesCommands(program: Command): void {
         printJson(result);
       });
     });
+}
+
+function extractAgentContextBody(result: Record<string, unknown>): unknown {
+  const agentContext = result.agent_context;
+
+  if (!agentContext || typeof agentContext !== 'object' || Array.isArray(agentContext)) {
+    throw new Error('Response missing agent_context.');
+  }
+
+  if (!('body' in agentContext)) {
+    throw new Error('Response missing agent_context.body.');
+  }
+
+  return agentContext.body;
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import type { Command } from 'commander';
 import { DEFAULT_BASE_URL, DEFAULT_PROFILE_NAME, ProfileManager } from '../profile-manager.js';
+import { validateBaseUrl } from './shared.js';
 
 export function buildLoginUrl(baseUrl: string): string {
   return `${baseUrl.replace(/\/+$/, '')}/cli/connect`;
@@ -80,6 +81,46 @@ export function validateToken(token: string): void {
   }
 }
 
+export function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+export function profileNameFromBaseUrl(baseUrl: string): string {
+  return new URL(baseUrl).hostname;
+}
+
+export function resolveLoginProfileName(
+  manager: Pick<ProfileManager, 'getProfile' | 'getProfileEntries'>,
+  baseUrl: string
+): string {
+  const normalizedUrl = normalizeBaseUrl(baseUrl);
+  const existingDefault = manager.getProfile(DEFAULT_PROFILE_NAME);
+
+  if (!existingDefault) {
+    return DEFAULT_PROFILE_NAME;
+  }
+
+  if (normalizeBaseUrl(existingDefault.base_url) === normalizedUrl) {
+    return DEFAULT_PROFILE_NAME;
+  }
+
+  for (const [name, profile] of manager.getProfileEntries()) {
+    if (normalizeBaseUrl(profile.base_url) === normalizedUrl) {
+      return name;
+    }
+  }
+
+  const derivedName = profileNameFromBaseUrl(baseUrl);
+  const existingDerived = manager.getProfile(derivedName);
+  if (existingDerived && normalizeBaseUrl(existingDerived.base_url) !== normalizedUrl) {
+    throw new Error(
+      `Profile '${derivedName}' already exists with a different base URL. Use 'prefactor profiles add <name> [baseUrl] --api-token <apiToken>' instead.`
+    );
+  }
+
+  return derivedName;
+}
+
 export interface LoginDeps {
   openBrowser: (url: string) => void;
   promptForToken: (prompt: string) => Promise<string>;
@@ -94,10 +135,12 @@ export function registerLoginCommand(program: Command, deps: LoginDeps = default
   program
     .command('login')
     .description('Authenticate the CLI with your Prefactor account')
-    .action(async () => {
+    .option('--base-url <baseUrl>', 'Prefactor app URL for the login flow')
+    .action(async (options: { baseUrl?: string }) => {
       const manager = await ProfileManager.create();
       const existing = manager.getProfile(DEFAULT_PROFILE_NAME);
-      const baseUrl = existing?.base_url ?? DEFAULT_BASE_URL;
+      const baseUrl = options.baseUrl ?? existing?.base_url ?? DEFAULT_BASE_URL;
+      validateBaseUrl(baseUrl);
       const loginUrl = buildLoginUrl(baseUrl);
 
       console.log(`Opening your browser to: ${loginUrl}`);
@@ -109,9 +152,8 @@ export function registerLoginCommand(program: Command, deps: LoginDeps = default
       const token = await deps.promptForToken('Paste your API token here: ');
       validateToken(token);
 
-      await manager.addProfile(DEFAULT_PROFILE_NAME, token, baseUrl);
-      console.log(
-        `Authentication successful. Credentials saved to the '${DEFAULT_PROFILE_NAME}' profile.`
-      );
+      const profileName = resolveLoginProfileName(manager, baseUrl);
+      await manager.addProfile(profileName, token, baseUrl);
+      console.log(`Authentication successful. Credentials saved to the '${profileName}' profile.`);
     });
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,10 +1,17 @@
 import { spawn } from 'node:child_process';
 import type { Command } from 'commander';
 import { DEFAULT_BASE_URL, DEFAULT_PROFILE_NAME, ProfileManager } from '../profile-manager.js';
-import { validateBaseUrl } from './shared.js';
+
+function stripTrailingSlashes(baseUrl: string): string {
+  let end = baseUrl.length;
+  while (end > 0 && baseUrl[end - 1] === '/') {
+    end--;
+  }
+  return end === baseUrl.length ? baseUrl : baseUrl.slice(0, end);
+}
 
 export function buildLoginUrl(baseUrl: string): string {
-  return `${baseUrl.replace(/\/+$/, '')}/cli/connect`;
+  return `${stripTrailingSlashes(baseUrl)}/cli/connect`;
 }
 
 function openBrowserImpl(url: string): void {
@@ -81,46 +88,6 @@ export function validateToken(token: string): void {
   }
 }
 
-export function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, '');
-}
-
-export function profileNameFromBaseUrl(baseUrl: string): string {
-  return new URL(baseUrl).hostname;
-}
-
-export function resolveLoginProfileName(
-  manager: Pick<ProfileManager, 'getProfile' | 'getProfileEntries'>,
-  baseUrl: string
-): string {
-  const normalizedUrl = normalizeBaseUrl(baseUrl);
-  const existingDefault = manager.getProfile(DEFAULT_PROFILE_NAME);
-
-  if (!existingDefault) {
-    return DEFAULT_PROFILE_NAME;
-  }
-
-  if (normalizeBaseUrl(existingDefault.base_url) === normalizedUrl) {
-    return DEFAULT_PROFILE_NAME;
-  }
-
-  for (const [name, profile] of manager.getProfileEntries()) {
-    if (normalizeBaseUrl(profile.base_url) === normalizedUrl) {
-      return name;
-    }
-  }
-
-  const derivedName = profileNameFromBaseUrl(baseUrl);
-  const existingDerived = manager.getProfile(derivedName);
-  if (existingDerived && normalizeBaseUrl(existingDerived.base_url) !== normalizedUrl) {
-    throw new Error(
-      `Profile '${derivedName}' already exists with a different base URL. Use 'prefactor profiles add <name> [baseUrl] --api-token <apiToken>' instead.`
-    );
-  }
-
-  return derivedName;
-}
-
 export interface LoginDeps {
   openBrowser: (url: string) => void;
   promptForToken: (prompt: string) => Promise<string>;
@@ -135,12 +102,10 @@ export function registerLoginCommand(program: Command, deps: LoginDeps = default
   program
     .command('login')
     .description('Authenticate the CLI with your Prefactor account')
-    .option('--base-url <baseUrl>', 'Prefactor app URL for the login flow')
-    .action(async (options: { baseUrl?: string }) => {
+    .action(async () => {
       const manager = await ProfileManager.create();
       const existing = manager.getProfile(DEFAULT_PROFILE_NAME);
-      const baseUrl = options.baseUrl ?? existing?.base_url ?? DEFAULT_BASE_URL;
-      validateBaseUrl(baseUrl);
+      const baseUrl = existing?.base_url ?? DEFAULT_BASE_URL;
       const loginUrl = buildLoginUrl(baseUrl);
 
       console.log(`Opening your browser to: ${loginUrl}`);
@@ -152,8 +117,9 @@ export function registerLoginCommand(program: Command, deps: LoginDeps = default
       const token = await deps.promptForToken('Paste your API token here: ');
       validateToken(token);
 
-      const profileName = resolveLoginProfileName(manager, baseUrl);
-      await manager.addProfile(profileName, token, baseUrl);
-      console.log(`Authentication successful. Credentials saved to the '${profileName}' profile.`);
+      await manager.addProfile(DEFAULT_PROFILE_NAME, token, baseUrl);
+      console.log(
+        `Authentication successful. Credentials saved to the '${DEFAULT_PROFILE_NAME}' profile.`
+      );
     });
 }

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createCli } from '../src/cli.js';
@@ -753,6 +753,90 @@ describe('CLI command validation', () => {
         '@/definitely/missing/file.json',
       ])
     ).rejects.toThrow('Unable to read file for --payload:');
+  });
+
+  test('agent_instances agent_context retrieves context response', async () => {
+    const cwd = join(tempRoot, 'cwd');
+    mkdirSync(cwd, { recursive: true });
+    process.chdir(cwd);
+    writeFileSync(
+      join(cwd, 'prefactor.json'),
+      JSON.stringify({ default: { api_key: 'token', base_url: 'https://example.com' } })
+    );
+
+    let capturedPath = '';
+    globalThis.fetch = (async (input) => {
+      capturedPath = new URL(String(input)).pathname;
+      return new Response(
+        JSON.stringify({
+          status: 'success',
+          agent_context: { body: { format: 'agent_context_v1' } },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }) as typeof fetch;
+
+    const log = mock(() => {});
+    const originalLog = console.log;
+    console.log = log;
+
+    try {
+      await createCli('1.0.0').parseAsync([
+        'node',
+        'prefactor',
+        'agent_instances',
+        'agent_context',
+        'agent_instance_1',
+      ]);
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(capturedPath).toBe('/api/v1/agent_instance/agent_instance_1/agent_context');
+    expect(log.mock.calls.flat().join('\n')).toContain('"agent_context"');
+  });
+
+  test('agent_instances agent_context writes context body to output file', async () => {
+    const cwd = join(tempRoot, 'cwd');
+    mkdirSync(cwd, { recursive: true });
+    process.chdir(cwd);
+    writeFileSync(
+      join(cwd, 'prefactor.json'),
+      JSON.stringify({ default: { api_key: 'token', base_url: 'https://example.com' } })
+    );
+
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          status: 'success',
+          agent_context: { body: { format: 'agent_context_v1', spans: [] } },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }) as typeof fetch;
+
+    const outputPath = join(cwd, 'context.json');
+
+    await createCli('1.0.0').parseAsync([
+      'node',
+      'prefactor',
+      'agent_instances',
+      'agent_context',
+      'agent_instance_1',
+      '--output',
+      outputPath,
+    ]);
+
+    expect(JSON.parse(readFileSync(outputPath, 'utf8'))).toEqual({
+      format: 'agent_context_v1',
+      spans: [],
+    });
   });
 
   test('enforces mutually exclusive span schema options', async () => {

--- a/packages/cli/tests/login.test.ts
+++ b/packages/cli/tests/login.test.ts
@@ -4,14 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
 import { createCli } from '../src/cli.js';
-import {
-  buildLoginUrl,
-  normalizeBaseUrl,
-  profileNameFromBaseUrl,
-  registerLoginCommand,
-  resolveLoginProfileName,
-  validateToken,
-} from '../src/commands/login.js';
+import { buildLoginUrl, registerLoginCommand, validateToken } from '../src/commands/login.js';
 import { DEFAULT_BASE_URL, DEFAULT_PROFILE_NAME, ProfileManager } from '../src/profile-manager.js';
 
 describe('buildLoginUrl', () => {
@@ -150,103 +143,6 @@ describe('login command action', () => {
     expect(profile?.base_url).toBe('https://custom.example.com');
   });
 
-  test('uses --base-url for login URL and saves it to the default profile when no default exists', async () => {
-    const cwd = join(tempRoot, 'cwd');
-    mkdirSync(cwd, { recursive: true });
-    process.chdir(cwd);
-
-    const openBrowser = mock(() => {});
-    const promptForToken = mock(async () => 'new-token');
-
-    const program = new Command();
-    program.exitOverride();
-    registerLoginCommand(program, { openBrowser, promptForToken });
-
-    await program.parseAsync(['node', 'prefactor', 'login', '--base-url', 'http://localhost:4000']);
-
-    expect(openBrowser).toHaveBeenCalledWith('http://localhost:4000/cli/connect');
-
-    const manager = await ProfileManager.create();
-    const profile = manager.getProfile(DEFAULT_PROFILE_NAME);
-    expect(profile).toEqual({
-      api_key: 'new-token',
-      base_url: 'http://localhost:4000',
-    });
-  });
-
-  test('does not overwrite default when --base-url differs from the existing default profile', async () => {
-    const cwd = join(tempRoot, 'cwd');
-    mkdirSync(cwd, { recursive: true });
-    writeFileSync(
-      join(cwd, 'prefactor.json'),
-      JSON.stringify({
-        default: { api_key: 'prod-token', base_url: 'https://app.prefactorai.com' },
-      })
-    );
-    process.chdir(cwd);
-
-    const openBrowser = mock(() => {});
-    const promptForToken = mock(async () => 'local-token');
-
-    const logs: string[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(' '));
-
-    try {
-      const program = new Command();
-      program.exitOverride();
-      registerLoginCommand(program, { openBrowser, promptForToken });
-      await program.parseAsync([
-        'node',
-        'prefactor',
-        'login',
-        '--base-url',
-        'http://localhost:4000',
-      ]);
-    } finally {
-      console.log = originalLog;
-    }
-
-    const manager = await ProfileManager.create();
-    expect(manager.getProfile(DEFAULT_PROFILE_NAME)).toEqual({
-      api_key: 'prod-token',
-      base_url: 'https://app.prefactorai.com',
-    });
-    expect(manager.getProfile('localhost')).toEqual({
-      api_key: 'local-token',
-      base_url: 'http://localhost:4000',
-    });
-    expect(logs.join('\n')).toContain("Credentials saved to the 'localhost' profile.");
-  });
-
-  test('updates an existing profile when login base URL matches that profile instead of default', async () => {
-    const cwd = join(tempRoot, 'cwd');
-    mkdirSync(cwd, { recursive: true });
-    writeFileSync(
-      join(cwd, 'prefactor.json'),
-      JSON.stringify({
-        default: { api_key: 'prod-token', base_url: 'https://app.prefactorai.com' },
-        localhost: { api_key: 'old-local-token', base_url: 'http://localhost:4000' },
-      })
-    );
-    process.chdir(cwd);
-
-    const openBrowser = mock(() => {});
-    const promptForToken = mock(async () => 'new-local-token');
-
-    const program = new Command();
-    program.exitOverride();
-    registerLoginCommand(program, { openBrowser, promptForToken });
-    await program.parseAsync(['node', 'prefactor', 'login', '--base-url', 'http://localhost:4000']);
-
-    const manager = await ProfileManager.create();
-    expect(manager.getProfile(DEFAULT_PROFILE_NAME)?.api_key).toBe('prod-token');
-    expect(manager.getProfile('localhost')).toEqual({
-      api_key: 'new-local-token',
-      base_url: 'http://localhost:4000',
-    });
-  });
-
   test('calls openBrowser with the derived URL', async () => {
     const cwd = join(tempRoot, 'cwd');
     mkdirSync(cwd, { recursive: true });
@@ -305,43 +201,6 @@ describe('login command action', () => {
     expect(logs.join('\n')).toContain(
       `Authentication successful. Credentials saved to the '${DEFAULT_PROFILE_NAME}' profile.`
     );
-  });
-});
-
-describe('resolveLoginProfileName', () => {
-  let tempRoot = '';
-
-  beforeEach(() => {
-    tempRoot = mkdtempSync(join(tmpdir(), 'prefactor-resolve-login-test-'));
-  });
-
-  afterEach(() => {
-    if (tempRoot) {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
-  });
-
-  test('uses default when no profile exists', async () => {
-    const manager = await ProfileManager.create(join(tempRoot, 'prefactor.json'));
-    expect(resolveLoginProfileName(manager, DEFAULT_BASE_URL)).toBe(DEFAULT_PROFILE_NAME);
-  });
-
-  test('uses default when base URL matches the existing default profile', async () => {
-    const manager = await ProfileManager.create(join(tempRoot, 'prefactor.json'));
-    await manager.addProfile(DEFAULT_PROFILE_NAME, 'token', 'https://app.prefactorai.com/');
-
-    expect(resolveLoginProfileName(manager, 'https://app.prefactorai.com')).toBe(
-      DEFAULT_PROFILE_NAME
-    );
-  });
-
-  test('derives a profile name from hostname when default uses a different base URL', async () => {
-    const manager = await ProfileManager.create(join(tempRoot, 'prefactor.json'));
-    await manager.addProfile(DEFAULT_PROFILE_NAME, 'token', 'https://app.prefactorai.com');
-
-    expect(resolveLoginProfileName(manager, 'http://localhost:4000')).toBe('localhost');
-    expect(profileNameFromBaseUrl('http://localhost:4000')).toBe('localhost');
-    expect(normalizeBaseUrl('https://app.prefactorai.com/')).toBe('https://app.prefactorai.com');
   });
 });
 

--- a/packages/cli/tests/login.test.ts
+++ b/packages/cli/tests/login.test.ts
@@ -4,7 +4,14 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
 import { createCli } from '../src/cli.js';
-import { buildLoginUrl, registerLoginCommand, validateToken } from '../src/commands/login.js';
+import {
+  buildLoginUrl,
+  normalizeBaseUrl,
+  profileNameFromBaseUrl,
+  registerLoginCommand,
+  resolveLoginProfileName,
+  validateToken,
+} from '../src/commands/login.js';
 import { DEFAULT_BASE_URL, DEFAULT_PROFILE_NAME, ProfileManager } from '../src/profile-manager.js';
 
 describe('buildLoginUrl', () => {
@@ -143,6 +150,103 @@ describe('login command action', () => {
     expect(profile?.base_url).toBe('https://custom.example.com');
   });
 
+  test('uses --base-url for login URL and saves it to the default profile when no default exists', async () => {
+    const cwd = join(tempRoot, 'cwd');
+    mkdirSync(cwd, { recursive: true });
+    process.chdir(cwd);
+
+    const openBrowser = mock(() => {});
+    const promptForToken = mock(async () => 'new-token');
+
+    const program = new Command();
+    program.exitOverride();
+    registerLoginCommand(program, { openBrowser, promptForToken });
+
+    await program.parseAsync(['node', 'prefactor', 'login', '--base-url', 'http://localhost:4000']);
+
+    expect(openBrowser).toHaveBeenCalledWith('http://localhost:4000/cli/connect');
+
+    const manager = await ProfileManager.create();
+    const profile = manager.getProfile(DEFAULT_PROFILE_NAME);
+    expect(profile).toEqual({
+      api_key: 'new-token',
+      base_url: 'http://localhost:4000',
+    });
+  });
+
+  test('does not overwrite default when --base-url differs from the existing default profile', async () => {
+    const cwd = join(tempRoot, 'cwd');
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(
+      join(cwd, 'prefactor.json'),
+      JSON.stringify({
+        default: { api_key: 'prod-token', base_url: 'https://app.prefactorai.com' },
+      })
+    );
+    process.chdir(cwd);
+
+    const openBrowser = mock(() => {});
+    const promptForToken = mock(async () => 'local-token');
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = new Command();
+      program.exitOverride();
+      registerLoginCommand(program, { openBrowser, promptForToken });
+      await program.parseAsync([
+        'node',
+        'prefactor',
+        'login',
+        '--base-url',
+        'http://localhost:4000',
+      ]);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const manager = await ProfileManager.create();
+    expect(manager.getProfile(DEFAULT_PROFILE_NAME)).toEqual({
+      api_key: 'prod-token',
+      base_url: 'https://app.prefactorai.com',
+    });
+    expect(manager.getProfile('localhost')).toEqual({
+      api_key: 'local-token',
+      base_url: 'http://localhost:4000',
+    });
+    expect(logs.join('\n')).toContain("Credentials saved to the 'localhost' profile.");
+  });
+
+  test('updates an existing profile when login base URL matches that profile instead of default', async () => {
+    const cwd = join(tempRoot, 'cwd');
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(
+      join(cwd, 'prefactor.json'),
+      JSON.stringify({
+        default: { api_key: 'prod-token', base_url: 'https://app.prefactorai.com' },
+        localhost: { api_key: 'old-local-token', base_url: 'http://localhost:4000' },
+      })
+    );
+    process.chdir(cwd);
+
+    const openBrowser = mock(() => {});
+    const promptForToken = mock(async () => 'new-local-token');
+
+    const program = new Command();
+    program.exitOverride();
+    registerLoginCommand(program, { openBrowser, promptForToken });
+    await program.parseAsync(['node', 'prefactor', 'login', '--base-url', 'http://localhost:4000']);
+
+    const manager = await ProfileManager.create();
+    expect(manager.getProfile(DEFAULT_PROFILE_NAME)?.api_key).toBe('prod-token');
+    expect(manager.getProfile('localhost')).toEqual({
+      api_key: 'new-local-token',
+      base_url: 'http://localhost:4000',
+    });
+  });
+
   test('calls openBrowser with the derived URL', async () => {
     const cwd = join(tempRoot, 'cwd');
     mkdirSync(cwd, { recursive: true });
@@ -201,6 +305,43 @@ describe('login command action', () => {
     expect(logs.join('\n')).toContain(
       `Authentication successful. Credentials saved to the '${DEFAULT_PROFILE_NAME}' profile.`
     );
+  });
+});
+
+describe('resolveLoginProfileName', () => {
+  let tempRoot = '';
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'prefactor-resolve-login-test-'));
+  });
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('uses default when no profile exists', async () => {
+    const manager = await ProfileManager.create(join(tempRoot, 'prefactor.json'));
+    expect(resolveLoginProfileName(manager, DEFAULT_BASE_URL)).toBe(DEFAULT_PROFILE_NAME);
+  });
+
+  test('uses default when base URL matches the existing default profile', async () => {
+    const manager = await ProfileManager.create(join(tempRoot, 'prefactor.json'));
+    await manager.addProfile(DEFAULT_PROFILE_NAME, 'token', 'https://app.prefactorai.com/');
+
+    expect(resolveLoginProfileName(manager, 'https://app.prefactorai.com')).toBe(
+      DEFAULT_PROFILE_NAME
+    );
+  });
+
+  test('derives a profile name from hostname when default uses a different base URL', async () => {
+    const manager = await ProfileManager.create(join(tempRoot, 'prefactor.json'));
+    await manager.addProfile(DEFAULT_PROFILE_NAME, 'token', 'https://app.prefactorai.com');
+
+    expect(resolveLoginProfileName(manager, 'http://localhost:4000')).toBe('localhost');
+    expect(profileNameFromBaseUrl('http://localhost:4000')).toBe('localhost');
+    expect(normalizeBaseUrl('https://app.prefactorai.com/')).toBe('https://app.prefactorai.com');
   });
 });
 

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -31,7 +31,7 @@
     "@prefactor/pfid": "^0.1.0"
   },
   "peerDependencies": {
-    "@prefactor/core": "^0.4.1",
+    "@prefactor/core": ">=0.4.0",
     "langchain": "^1.0.0"
   },
   "engines": {

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -31,7 +31,7 @@
     "@prefactor/pfid": "^0.1.0"
   },
   "peerDependencies": {
-    "@prefactor/core": ">=0.4.0",
+    "@prefactor/core": "^0.4.0",
     "langchain": "^1.0.0"
   },
   "engines": {

--- a/packages/livekit/package.json
+++ b/packages/livekit/package.json
@@ -28,7 +28,7 @@
   "author": "Prefactor",
   "license": "MIT",
   "peerDependencies": {
-    "@prefactor/core": "^0.4.1",
+    "@prefactor/core": ">=0.4.0",
     "@livekit/agents": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/livekit/package.json
+++ b/packages/livekit/package.json
@@ -28,7 +28,7 @@
   "author": "Prefactor",
   "license": "MIT",
   "peerDependencies": {
-    "@prefactor/core": ">=0.4.0",
+    "@prefactor/core": "^0.4.0",
     "@livekit/agents": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/openclaw-prefactor-plugin/package.json
+++ b/packages/openclaw-prefactor-plugin/package.json
@@ -34,7 +34,7 @@
     "zod": "^4.0.0"
   },
   "peerDependencies": {
-    "@prefactor/core": "^0.3.0"
+    "@prefactor/core": ">=0.4.0"
   },
   "devDependencies": {
     "openclaw": "^2026.3.28",

--- a/packages/openclaw-prefactor-plugin/package.json
+++ b/packages/openclaw-prefactor-plugin/package.json
@@ -34,7 +34,7 @@
     "zod": "^4.0.0"
   },
   "peerDependencies": {
-    "@prefactor/core": ">=0.4.0"
+    "@prefactor/core": "^0.4.0"
   },
   "devDependencies": {
     "openclaw": "^2026.3.28",

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -13,6 +13,8 @@ Use this file as a router for Prefactor skills.
 - `skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md`: instrument an existing agent with Prefactor SDK so coding tools can see runs, llm/tool spans, token usage, and failures.
 - `skills/create-provider-package-with-core/SKILL.md`: create a new provider package as a thin adapter over `@prefactor/core` with core-first boundaries and tracing conventions.
 - `skills/report-agent-risk-data/SKILL.md`: populate `data_risk` fields on span types for compliance tracking and data governance after an agent is already instrumented.
+- `skills/write-span-summary-templates/SKILL.md`: write Liquid display templates on span type schemas so traces show readable one-line summaries in the Prefactor UI.
+- `skills/inspect-agent-run-with-prefactor-cli/SKILL.md`: perform root-cause analysis on a Prefactor agent run from CLI span data; run in the agent's own codebase (user provides instance ID and symptom).
 
 ## Selection Rules
 
@@ -20,6 +22,8 @@ Use this file as a router for Prefactor skills.
 - If the request is about adding telemetry to an existing agent without rewriting business logic, load `skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md`.
 - If the request is about creating a custom provider adapter with `@prefactor/core`, load `skills/create-provider-package-with-core/SKILL.md`.
 - If the request is about adding risk or compliance metadata to span types, load `skills/report-agent-risk-data/SKILL.md`.
+- If the request is about span summary templates, display templates, Liquid templates on schemas, or making spans readable in the Prefactor UI, load `skills/write-span-summary-templates/SKILL.md`.
+- If the request is about root-cause analysis on a bad, surprising, expensive, incomplete, or downvoted agent run, load `skills/inspect-agent-run-with-prefactor-cli/SKILL.md`.
 
 ## Default Workflow
 
@@ -32,3 +36,4 @@ When instrumenting an existing agent, default to this order:
 5. If no matching adapter package exists, use `skills/create-provider-package-with-core/SKILL.md`.
 6. Instrument the existing agent with `skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md`.
 7. Optionally populate compliance metadata with `skills/report-agent-risk-data/SKILL.md`.
+8. Optionally add readable trace summaries with `skills/write-span-summary-templates/SKILL.md`.

--- a/skills/inspect-agent-run-with-prefactor-cli/SKILL.md
+++ b/skills/inspect-agent-run-with-prefactor-cli/SKILL.md
@@ -9,7 +9,7 @@ Perform root-cause analysis on a specific agent run using Prefactor span data.
 
 ## When to use
 
-The user has already decided something in a run is wrong or worth investigating. They paste identifiers and a symptom; your job is to analyze the spans and deliver a **findings report** — what happened, why (through five whys), and where in the codebase it connects.
+The user has already decided something in a run is wrong or worth investigating. They paste identifiers and a symptom; your job is to analyze the spans and deliver a **findings report** — what happened, what caused it, and where in the codebase it connects.
 
 Do not prescribe fixes or recommended next actions. The human team owns remediation; your output equips their post-mortem with evidence and source locations.
 
@@ -49,11 +49,13 @@ This skill is for real root-cause analysis, not trigger spotting.
 - The local codebase is where those "why" answers usually live — cross-read spans against source, not spans alone.
 - Treat technical findings as evidence. The final answer often requires human judgment about intent, process, and ownership.
 
-**Five whys**
+**Five whys (internal reasoning only)**
 
+- Use a five-whys approach to trace root causes during analysis, but do not print the why chain in the report.
 - Work through at least five "why" steps from the user-visible symptom down to systemic conditions.
 - Question the accepted truth. If spans show "tool returned empty," ask why empty was acceptable, why the agent did not recover, why the prompt did not constrain that failure mode, why nothing caught it earlier.
-- Each why must be labeled **confirmed** (span evidence), **inferred** (strong circumstantial), or **hypothesis** (needs human validation).
+- Label each step internally as **confirmed** (span evidence), **inferred** (strong circumstantial), or **hypothesis** (needs human validation).
+- Synthesize the conclusions into **What we found** — a flat list of named issues with evidence, not a numbered why chain.
 
 **What automation is good for here**
 
@@ -83,7 +85,7 @@ If the user only has an agent ID, list instances and pick the run that matches t
 Start with the context export for the instance under investigation:
 
 ```bash
-prefactor --profile <profile> agent_instances agent_context <agent-instance-id> --output /tmp/prefactor-agent-context.json
+prefactor --profile <profile> agent_instances agent_context <agent-instance-id> --output ./tmp/prefactor-agent-context.json
 ```
 
 If `agent_context` is not available on that profile, use span listing with summaries:
@@ -129,9 +131,11 @@ For each item, report findings from specific span IDs or `not observed`:
 
 Multiple independent faults can coexist. Do not collapse them into a single "the cause."
 
-## Five whys workflow
+## Root-cause reasoning workflow
 
-After span analysis, walk the chain explicitly:
+After span analysis, use five whys as a private thinking method — not as report structure.
+
+Walk the chain internally:
 
 1. **Symptom** — what the user saw, confirmed in spans where possible.
 2. **Why did that happen?** — first layer; often a specific span, tool, or LLM event (usually the trigger).
@@ -139,49 +143,47 @@ After span analysis, walk the chain explicitly:
 4. **Why was that gap present?** — design choice, missing test, operational constraint, undocumented assumption.
 5. **Why was it not caught earlier?** — monitoring, review process, ownership, false confidence.
 
-Continue beyond five if the chain is still shallow. Stop when you reach a systemic condition a human would need to change — and say so plainly.
+Continue beyond five if the chain is still shallow. Stop when you reach a systemic condition a human would need to change.
+
+Then synthesize: distill each confirmed or strongly inferred conclusion into a named finding in **What we found**. Include triggers, root causes, and contributing factors as separate findings when they are distinct — but never as a "why #1 → why #2" chain.
+
+When linked instances were inspected, fold that into findings or the timeline; do not add a separate linked-instances section.
 
 ## Output format
 
 Deliver a findings report, not an action plan. Use these exact sections, even when the user asks for a concise answer:
 
-### Symptom
+### Summary
 
-What the user reported and what spans confirm about user-visible impact.
+One short paragraph: what happened, what the user experienced, and your verdict on why. No why chain here — just the conclusion a reader needs first.
+
+### What we found
+
+Concrete issues as a flat list of named findings. Each finding gets:
+
+- A short title (the issue in plain language).
+- The conclusion — what went wrong and why, stated directly.
+- Evidence — span IDs, instance IDs, code locations, token counts, payload sizes, or concrete values.
+- Confidence — **confirmed**, **inferred**, or **hypothesis**.
+
+Include triggers, root causes, and contributing factors as separate findings when they are distinct. Do not output the five-whys chain itself.
 
 ### Timeline
 
-Ordered key events with span IDs and one-line summaries.
+Ordered key events with span IDs and one-line summaries. Include linked-instance events here when relevant.
 
-### Trigger
+### What's still unknown
 
-The immediate technical event that produced the symptom. Ground in span evidence.
+Explicit gaps that set honest expectations: missing context, human/process factors, intent behind prompts or schemas, conclusions that could not be verified because the workspace is not the agent's codebase.
 
-### Root cause analysis (five whys)
+### Code pointers
 
-Numbered why chain. Mark each step **confirmed**, **inferred**, or **hypothesis**.
+A trimmed table of source locations directly relevant to the findings above — not a fix list, and not an exhaustive tour of the repo. For each entry:
 
-### Contributing factors
+- File path and symbol (function, class, module, or config key).
+- Which finding it supports.
+- One line on why it matters.
 
-Separate issues that did not alone cause the symptom but increased likelihood or severity.
-
-### Linked instances
-
-Which linked runs were inspected and what they changed — or `none / not applicable`.
-
-### What spans cannot answer
-
-Explicit gaps: missing context, human/process factors, intent behind prompts or schemas. Note any conclusions that could not be verified because the workspace is not the agent's codebase.
-
-### Codebase points of interest
-
-Relevant source tied to the findings — not a fix list. For each point, link span evidence to local code:
-
-- File paths and symbols (functions, classes, modules, config keys).
-- Prompt templates, system instructions, or context-assembly code when LLM behavior is in question.
-- Tool handlers, validators, and error paths when tool spans are involved.
-- Span schema registration and instrumentation when payload shape or missing fields matter.
-
-Use code citations when referencing source. Explain briefly why each location matters to the investigation.
+Cover prompt templates, tool handlers, validators, and span schema registration only when a finding depends on them. Use code citations when referencing source.
 
 Ground every technical claim in span IDs, instance IDs, summaries, token counts, payload sizes, or concrete payload/result values.

--- a/skills/inspect-agent-run-with-prefactor-cli/SKILL.md
+++ b/skills/inspect-agent-run-with-prefactor-cli/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: inspect-agent-run-with-prefactor-cli
+description: Use when performing root-cause analysis on a Prefactor agent run — bad output, surprising behavior, high cost, incomplete work, downvotes, or anything worth investigating. Run in the agent's own codebase. User provides agent instance ID (and agent ID if needed).
+---
+
+# Inspect Agent Run With Prefactor CLI
+
+Perform root-cause analysis on a specific agent run using Prefactor span data.
+
+## When to use
+
+The user has already decided something in a run is wrong or worth investigating. They paste identifiers and a symptom; your job is to analyze the spans and deliver a **findings report** — what happened, why (through five whys), and where in the codebase it connects.
+
+Do not prescribe fixes or recommended next actions. The human team owns remediation; your output equips their post-mortem with evidence and source locations.
+
+Typical handoff:
+
+- Agent ID (required)
+- Agent Instance ID (when listing specific instances or resolving context)
+- What went wrong, what surprised them, or what they want explained — may be ambiguous.
+
+## Run in the agent's codebase
+
+Run this skill from the repository that deployed the agent under investigation — not from the Prefactor SDK repo or an unrelated project. Assume you are running in the correct repo and thus have access to the full codebase of the traces.
+
+Spans show runtime behavior. The agent's codebase holds the prompts, tool implementations, schemas, guardrails, and wiring that explain *why* the system behaved that way. Root-cause analysis needs both:
+
+- **Prefactor CLI** — fetch spans, timelines, token use, linked instances.
+- **Local source** — read the code and config that produced those spans.
+
+When a span points at a tool call, find that tool's handler in this repo. When an LLM span shows a bloated prompt, find where that context is assembled. When schema fields look wrong or missing, find the registered span types here. Human-factor whys often resolve in this codebase even when spans only show the symptom.
+
+If the workspace does not match the agent that produced the run, say so before drawing conclusions — you may be missing the source of truth for prompts, tools, and schemas.
+
+## RCA philosophy
+
+This skill is for real root-cause analysis, not trigger spotting.
+
+**Trigger vs root cause**
+
+- A **trigger** is the immediate event that made the failure visible: a bad tool result, timeout, hallucinated answer, runaway retry loop.
+- A **root cause** is the condition that made that trigger possible and likely to recur.
+- Nine times out of ten, "RCA" in the wild stops at the trigger. Do not stop there.
+
+**Human factors**
+
+- Most incidents ultimately involve human factors: unclear prompts, missing guardrails, wrong assumptions in schemas, untested edge cases, operational pressure, incomplete context given to the agent, handoffs without verification.
+- Spans show what the system did. They rarely prove why it was built that way or why the agent received bad inputs.
+- The local codebase is where those "why" answers usually live — cross-read spans against source, not spans alone.
+- Treat technical findings as evidence. The final answer often requires human judgment about intent, process, and ownership.
+
+**Five whys**
+
+- Work through at least five "why" steps from the user-visible symptom down to systemic conditions.
+- Question the accepted truth. If spans show "tool returned empty," ask why empty was acceptable, why the agent did not recover, why the prompt did not constrain that failure mode, why nothing caught it earlier.
+- Each why must be labeled **confirmed** (span evidence), **inferred** (strong circumstantial), or **hypothesis** (needs human validation).
+
+**What automation is good for here**
+
+- Fetching and organizing span evidence quickly.
+- Contradiction checks: what the agent said vs what tools actually returned.
+- Timeline reconstruction, token/cost anomalies, payload bloat, retry patterns.
+- Hypothesis generation — not hypothesis closure without human input.
+
+Do not treat span data as a substitute for a post-mortem conversation. Use it to make the conversation sharper.
+
+## Inputs
+
+Collect before starting:
+
+- **Agent's repository** — the project that runs the instrumented agent (current workspace should be this repo).
+- Prefactor CLI command, usually `prefactor` or a package-manager launcher.
+- Profile name or `PREFACTOR_API_URL` / `PREFACTOR_API_TOKEN`.
+- Agent ID from the user.
+- Agent Instance ID when you need to list instances or disambiguate runs.
+- The user's symptom or investigation question.
+- Approximate time window, if the profile does not support `agent_context`.
+
+If the user only has an agent ID, list instances and pick the run that matches their time window or description.
+
+## CLI workflow
+
+Start with the context export for the instance under investigation:
+
+```bash
+prefactor --profile <profile> agent_instances agent_context <agent-instance-id> --output /tmp/prefactor-agent-context.json
+```
+
+If `agent_context` is not available on that profile, use span listing with summaries:
+
+```bash
+prefactor --profile <profile> agent_spans list \
+  --agent_instance_id <agent-instance-id> \
+  --start_time <iso-start> \
+  --end_time <iso-end> \
+  --include_summaries
+```
+
+Read spans in execution order. Build a timeline: user input → agent decisions → LLM calls → tool calls → intermediate outputs → final response.
+
+Note where the user-visible outcome diverged from source data. That divergence point is usually near the trigger, not the root cause.
+
+## Linked instances (optional)
+
+Not every agent delegates work. Some runs are fully self-contained; others spawn subagents, jobs, or linked runs. Treat linked instances as conditional follow-up, not a required step.
+
+Follow linked runs only when span payloads point to another instance that may explain user-visible output, missing output, errors, cost spikes, or incomplete work. Linked instance IDs often appear under keys such as `subagent_agent_instance_id`, `agent_instance_id`, `jobId`, `outputs`, or `result_payload`.
+
+When a linked instance looks relevant:
+
+```bash
+prefactor --profile <profile> agent_instances agent_context <linked-agent-instance-id> --output /tmp/prefactor-linked-agent-context.json
+```
+
+Use the same span-listing fallback when `agent_context` is unavailable. Stop expanding the graph when additional linked runs no longer change the story.
+
+If no delegation signals appear in spans, report linked instances as `none / not applicable` and continue analysis on the main instance.
+
+## Span analysis checklist
+
+For each item, report findings from specific span IDs or `not observed`:
+
+- **User-visible outcome**: final assistant text, result previews, and tool outputs vs source data in spans — where did divergence start?
+- **Feedback signals**: quality or downvote spans — treat as leads; confirm the mechanism in LLM, tool, or linked-instance spans.
+- **Decision points**: tool selection, argument values, early termination, ignored tool results.
+- **Tool and LLM failures**: errors, empty results, retries, unexpected finish reasons.
+- **Token and payload anomalies**: large prompts, bloated context, repeated schemas, growing accumulated fields.
+- **State**: instance status, span counts, failed/pending spans, unfinished work.
+
+Multiple independent faults can coexist. Do not collapse them into a single "the cause."
+
+## Five whys workflow
+
+After span analysis, walk the chain explicitly:
+
+1. **Symptom** — what the user saw, confirmed in spans where possible.
+2. **Why did that happen?** — first layer; often a specific span, tool, or LLM event (usually the trigger).
+3. **Why was that allowed?** — missing validation, bad upstream input, wrong tool choice, prompt gap.
+4. **Why was that gap present?** — design choice, missing test, operational constraint, undocumented assumption.
+5. **Why was it not caught earlier?** — monitoring, review process, ownership, false confidence.
+
+Continue beyond five if the chain is still shallow. Stop when you reach a systemic condition a human would need to change — and say so plainly.
+
+## Output format
+
+Deliver a findings report, not an action plan. Use these exact sections, even when the user asks for a concise answer:
+
+### Symptom
+
+What the user reported and what spans confirm about user-visible impact.
+
+### Timeline
+
+Ordered key events with span IDs and one-line summaries.
+
+### Trigger
+
+The immediate technical event that produced the symptom. Ground in span evidence.
+
+### Root cause analysis (five whys)
+
+Numbered why chain. Mark each step **confirmed**, **inferred**, or **hypothesis**.
+
+### Contributing factors
+
+Separate issues that did not alone cause the symptom but increased likelihood or severity.
+
+### Linked instances
+
+Which linked runs were inspected and what they changed — or `none / not applicable`.
+
+### What spans cannot answer
+
+Explicit gaps: missing context, human/process factors, intent behind prompts or schemas. Note any conclusions that could not be verified because the workspace is not the agent's codebase.
+
+### Codebase points of interest
+
+Relevant source tied to the findings — not a fix list. For each point, link span evidence to local code:
+
+- File paths and symbols (functions, classes, modules, config keys).
+- Prompt templates, system instructions, or context-assembly code when LLM behavior is in question.
+- Tool handlers, validators, and error paths when tool spans are involved.
+- Span schema registration and instrumentation when payload shape or missing fields matter.
+
+Use code citations when referencing source. Explain briefly why each location matters to the investigation.
+
+Ground every technical claim in span IDs, instance IDs, summaries, token counts, payload sizes, or concrete payload/result values.

--- a/skills/write-span-summary-templates/SKILL.md
+++ b/skills/write-span-summary-templates/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: write-span-summary-templates
+description: Use when writing or fixing span summary templates (display templates) on Prefactor span type schemas, when spans show raw JSON or blank summaries in the Prefactor UI, or when you want one-line Liquid summaries of agent, llm, tool, and custom spans.
+---
+
+# Write Span Summary Templates
+
+Write Liquid display templates on span type schemas so each span shows a short, readable summary in the Prefactor UI instead of raw JSON.
+
+Core principle: a template summarizes what happened in one line, built from the high-signal fields the span already sends.
+
+## Trigger Phrases
+
+Apply this skill when the user asks for any of these:
+
+- "write span summary templates"
+- "add display templates to my schemas"
+- "my spans show raw JSON / blank summaries in Prefactor"
+- "how do Prefactor templates work"
+- "Liquid template for span types"
+- "make my traces readable"
+
+## Prerequisite
+
+Your agent must already register an `agent_schema_version` with `span_type_schemas`. If it does not yet:
+
+- Instrument it first with `skills/instrument-existing-agent-with-prefactor-sdk/SKILL.md`.
+- Building a custom adapter? See `skills/create-provider-package-with-core/SKILL.md`.
+
+You add templates to the schemas you register; the Prefactor backend renders them. The SDK never renders templates locally.
+
+## Quick Start
+
+1. List the span types your agent emits (e.g. `myapp:llm`, `myapp:tool:search`).
+2. For each, pick the few fields that explain it at a glance (model, tool name, status, counts).
+3. Note which fields come from the **start** payload and which from the **finish** result.
+4. Write a short Liquid `template` string per span type.
+5. Set `template` on each entry in `span_type_schemas`.
+6. Make sure your instrumentation actually sends every field the template references.
+7. Verify summaries in the Prefactor UI (the list API returns them when `include_summaries: true`).
+
+## What Templates Do
+
+A template renders to the `summary` field shown in Prefactor trace lists. Good summaries:
+
+- Are short and field-driven: the action, the subject, optionally the outcome.
+- Distinguish similar spans so a list is scannable.
+- Never dump full prompts or full outputs.
+
+## Where the Template Goes
+
+Set `template` on each span type schema in the agent schema version you register:
+
+```ts
+import type { AgentSchemaVersion } from '@prefactor/core';
+
+const agentSchema: AgentSchemaVersion = {
+  external_identifier: 'myapp-schema-v1',
+  span_type_schemas: [
+    {
+      name: 'myapp:llm',
+      template: 'LLM {{ model }}{% if total_tokens %}: {{ total_tokens }} tokens{% endif %}{% if finish_reason %} -> {{ finish_reason }}{% endif %}',
+      params_schema: {
+        type: 'object',
+        properties: { model: { type: 'string' } },
+      },
+      result_schema: {
+        type: 'object',
+        properties: {
+          total_tokens: { type: 'integer' },
+          finish_reason: { type: 'string' },
+        },
+      },
+    },
+  ],
+};
+```
+
+The LiveKit package is the reference implementation in this repo: see `packages/livekit/src/schema.ts` for production templates and `packages/livekit/tests/schema.test.ts` for how they are tested.
+
+### If your schema uses the legacy `span_schemas` maps
+
+Some agents (and the `@prefactor/ai` and `@prefactor/langchain` defaults) register the older shape: a `span_schemas` map and a `span_result_schemas` map keyed by span type, with no place for a template. Templates only live on `span_type_schemas` entries.
+
+Migrate each span type into a `span_type_schemas` array: carry the per-type `span_schemas` entry into `params_schema`, the `span_result_schemas` entry into `result_schema`, and add the `template`. When `span_type_schemas` is present the backend uses it and ignores the legacy maps, so drop the maps once everything is migrated rather than maintaining two copies.
+
+```ts
+const agentSchema = {
+  external_identifier: 'myapp-schema-v1',
+  span_type_schemas: [
+    {
+      name: 'ai-sdk:llm',
+      template: 'LLM {{ inputs["ai.model.id"] }}',
+      params_schema: { type: 'object', additionalProperties: true },
+      result_schema: { type: 'object', additionalProperties: true },
+    },
+  ],
+};
+```
+
+The array survives provider normalization (`@prefactor/ai` and `@prefactor/langchain` pass it through), so the templates reach the backend.
+
+### Tools declared via `toolSchemas`
+
+Some agents register tools under `toolSchemas` instead of listing each tool in `span_type_schemas`. The SDK still resolves runtime span types from `toolSchemas`, but **templates only apply to entries in `span_type_schemas`**.
+
+Each `toolSchemas` entry gets a generated span type name:
+
+`<provider>:tool:<spanTypeSuffix>`
+
+- **provider** is the adapter prefix (`langchain`, `ai-sdk`).
+- **spanTypeSuffix** comes from the entry's `spanType` field after normalization (e.g. `spanType: 'calculator'` with `@prefactor/langchain` → `langchain:tool:calculator`).
+
+When `span_type_schemas` is present the backend uses it and ignores legacy maps. Tool schemas that `toolSchemas` would have injected into those maps are ignored too unless you also list each tool span type in `span_type_schemas`. Keep `toolSchemas` for SDK runtime span-type resolution; add a matching `span_type_schemas` entry for every tool you want summarized.
+
+```ts
+const agentSchema = {
+  external_identifier: 'langchain-tool-schema-example-v2',
+  span_type_schemas: [
+    {
+      name: 'custom:example-root',
+      template: 'Example root: {{ inputs.example }}',
+      params_schema: { type: 'object', additionalProperties: true },
+      result_schema: { type: 'object', additionalProperties: true },
+    },
+    {
+      name: 'langchain:tool:calculator',
+      template:
+        'Tool {{ inputs.toolName }}{% if inputs.input.expression %}: {{ inputs.input.expression }}{% endif %}{% if outputs.output %} -> {{ outputs.output | truncate: 60 }}{% endif %}',
+      params_schema: { type: 'object', additionalProperties: true },
+      result_schema: { type: 'object', additionalProperties: true },
+    },
+  ],
+  toolSchemas: {
+    calculator: {
+      spanType: 'calculator',
+      inputSchema: {
+        type: 'object',
+        properties: { expression: { type: 'string' } },
+        required: ['expression'],
+      },
+    },
+  },
+};
+```
+
+Common field paths for `@prefactor/langchain` and `@prefactor/ai` tool spans:
+
+- `inputs.toolName` — tool name
+- `inputs.input.<field>` — tool arguments (e.g. `inputs.input.expression`)
+- `outputs.output` — tool result (often a string; use `truncate`)
+
+When no per-tool schema exists, spans fall back to the generic type (`langchain:tool`, `ai-sdk:tool`). Template those separately if you want a catch-all summary.
+
+### `@prefactor/ai` and `@prefactor/langchain` middleware spans
+
+These adapters emit **LLM and tool** spans through middleware. Payloads use the transport envelope: start fields under `inputs`, finish fields under `outputs`. Prefer `outputs["dotted.key"]` bracket paths for finish fields with dots in the name.
+
+**Agent span types (`ai-sdk:agent`, `langchain:agent`)** — present in default schemas but **not emitted** by current middleware. Agent runs are tracked via agent instance lifecycle, not an agent span. If your schema lists these types but your app never emits them, use a static template or omit one:
+
+```liquid
+Agent run
+```
+
+Only reference runtime fields when you actually emit spans with that `spanType`.
+
+**`ai-sdk:llm`**
+
+```liquid
+LLM {{ inputs["ai.model.id"] }}{% if inputs["ai.model.provider"] %} ({{ inputs["ai.model.provider"] }}){% endif %}{% if outputs["ai.response.text"] %} -> {{ outputs["ai.response.text"] | truncate: 60 }}{% endif %}
+```
+
+- Start: `inputs["ai.model.id"]`, `inputs["ai.model.provider"]`
+- Finish: `outputs["ai.response.text"]`, `outputs["ai.finishReason"]`
+
+**`ai-sdk:tool`** (generic; per-tool types use `ai-sdk:tool:<suffix>` from `toolSchemas`)
+
+```liquid
+Tool {{ inputs.toolName }}{% if outputs.output %} -> {{ outputs.output | truncate: 60 }}{% endif %}
+```
+
+**`langchain:llm`**
+
+```liquid
+LLM {{ inputs["langchain.model.name"] }}{% if outputs.content %} -> {{ outputs.content | truncate: 60 }}{% endif %}
+```
+
+- Start: `inputs["langchain.model.name"]`
+- Finish: `outputs.content`
+
+**`langchain:tool`** (generic; per-tool types use `langchain:tool:<suffix>` from `toolSchemas`)
+
+Same field paths as `ai-sdk:tool`: `inputs.toolName`, `inputs.input.<field>`, `outputs.output`.
+
+### Custom spans (`withSpan`)
+
+Manual spans created with `prefactor.withSpan` or `@prefactor/core`'s `withSpan` use a different payload shape from adapter middleware spans.
+
+**Start fields** — whatever you pass as `inputs` in the `withSpan` call is sent under an `inputs` key in the span payload. Template start fields as `{{ inputs.<field> }}`, not `{{ <field> }}`:
+
+```ts
+await prefactor.withSpan(
+  {
+    name: 'custom:example-root',
+    spanType: 'custom:example-root',
+    inputs: { example: 'my-agent/run.ts' },
+  },
+  async () => { /* ... */ }
+);
+```
+
+```liquid
+Example root: {{ inputs.example }}
+```
+
+**Finish fields** — the callback return value becomes `result_payload`:
+
+- If the callback returns a **plain object**, its keys merge at the **top level** of the template context (e.g. `{ preview, wordCount }` → `{{ preview }}`, `{{ wordCount }}`).
+- If the callback returns a **string, number, or other non-object**, it is wrapped as `{{ result }}`.
+
+```ts
+// returns a string → result_payload: { result: "..." }
+await prefactor.withSpan(
+  { spanType: 'custom:normalize-response', inputs: { rawLength: 120 } },
+  async () => 'normalized text'
+);
+// template: Normalized {{ inputs.rawLength }} chars{% if result %} -> {{ result | truncate: 60 }}{% endif %}
+
+// returns an object → result_payload: { preview: "...", wordCount: 42 }
+await prefactor.withSpan(
+  { spanType: 'custom:build-summary', inputs: { normalizedLength: 120 } },
+  async () => ({ preview: '...', wordCount: 42 })
+);
+// template: Summary {{ wordCount }} words{% if preview %}: {{ preview | truncate: 60 }}{% endif %}
+```
+
+Register each custom `spanType` in `span_type_schemas` the same way as any other span type.
+
+## Which Fields You Can Reference
+
+At render time the backend merges the start payload and finish result into one context. A single `template` can reference both, and on a name collision the **finish (result) value wins**.
+
+Reference fields by the exact shape your provider actually sends, not by a guessed name. The shape is provider-specific:
+
+- **Custom `withSpan` spans** — start fields under `inputs` (`{{ inputs.example }}`); finish object fields at the top level (`{{ preview }}`); string/primitive finishes as `{{ result }}`.
+- **`@prefactor/ai` / `@prefactor/langchain` middleware** — LLM and tool spans use the `inputs` / `outputs` envelope (`{{ inputs["ai.model.id"] }}`, `{{ outputs["ai.response.text"] }}`, `{{ inputs.toolName }}`, `{{ outputs.output }}`). Agent span types (`ai-sdk:agent`, `langchain:agent`) are schema defaults only unless you emit them yourself.
+- **LiveKit and other adapters** — same envelope pattern in many cases (`{{ outputs.name }}`, `{{ outputs.message.content }}`).
+
+When in doubt, look at one real span in the Prefactor UI (or the JSON payload) and mirror the field paths you see. Because most summaries are read after a span finishes, it is normal to mix start fields (e.g. `model`) and finish fields (e.g. `finish_reason`) in one template.
+
+### Field keys that contain dots
+
+A dot in a template means "traverse into an object". If a provider sends a literal key that contains a dot (e.g. the AI SDK key `ai.model.id`), dot syntax would wrongly traverse it. Use bracket notation with a quoted string on its parent instead:
+
+```liquid
+{{ inputs["ai.model.id"] }}
+```
+
+A dotted key only works when it hangs off a parent variable. There is no clean syntax for a bare top-level identifier that contains dots, so do not write `{{ ai.response.text }}`. In practice these fields are sent inside an `inputs` / `outputs` envelope, so reference them off that parent (`{{ outputs["ai.response.text"] }}`). If a dotted field really is at the very top level with no parent, you cannot reference it from a template; surface it under an envelope key from instrumentation first.
+
+## Liquid Syntax Cheat Sheet
+
+Prefactor uses Liquid (via Solid). These are the constructs you need:
+
+```liquid
+{{ model }}
+{{ conversation.userMessages }}
+{% if transcript %}User: {{ transcript }}{% else %}User turn{% endif %}
+{% if status == "cancelled" %} -> cancelled{% endif %}
+{{ toolName | default: "(unknown)" }}
+{{ output | truncate: 60 }}
+```
+
+Standard Liquid filters work. The useful ones for summaries are `default: "..."` (fallback for missing values), `truncate: N` and `truncatewords: N` (cap long text), and `size` (length of a string or list). Use `truncate` to include an output preview without dumping the whole field.
+
+Rules:
+
+- Use **nested dot paths** to reach into objects: `{{ metadata.closeReason }}`, not `{{ metadata }}`. A bare object or array at a `{{ var }}` leaf renders as empty.
+- Wrap every optional field in `{% if %}` so the summary still reads well when it is absent.
+- Missing or null fields render as an empty string (rendering is non-strict).
+
+## Authoring Checklist
+
+Before shipping schema or template changes:
+
+- [ ] Every `{{ var }}` is a field your instrumentation sends when the summary is shown.
+- [ ] Optional fields are wrapped in conditionals.
+- [ ] Similar span types produce distinguishable summaries.
+- [ ] Schema, template, and instrumentation are updated together.
+- [ ] Every `toolSchemas` entry you want summarized has a matching `span_type_schemas` entry named `<provider>:tool:<spanTypeSuffix>`.
+- [ ] Custom `withSpan` start fields use the `inputs.<field>` path, not bare top-level names.
+- [ ] `ai-sdk:agent` / `langchain:agent` templates are static unless you actually emit those span types.
+
+## Common Pitfalls
+
+- `result_template` is not rendered by the backend today. Put both start and finish fields in the single `template`.
+- Invalid Liquid fails silently: the span just gets no summary. Recheck syntax if a summary is missing.
+- Active (unfinished) spans will not have finish fields yet, so the summary shows only what is available so far.
+- Do not patch a missing field with literal template text. If the template needs a value, send that value from instrumentation.
+
+## Additional Resources
+
+- Copy-paste patterns by span type: [references/template-examples.md](references/template-examples.md)
+- In-repo reference templates: `packages/livekit/src/schema.ts`

--- a/skills/write-span-summary-templates/references/template-examples.md
+++ b/skills/write-span-summary-templates/references/template-examples.md
@@ -1,0 +1,171 @@
+# Template Examples
+
+Copy-paste Liquid templates for common span types. Each row notes which fields come from the **start** payload (`startSpan` inputs) and which from the **finish** result (`endSpan` outputs). Adapt field names to what your instrumentation actually sends.
+
+## Simple field interpolation
+
+```liquid
+{{ model }}
+```
+
+- `model` — start. Renders the model name only. Good as a minimal fallback.
+
+## LLM call
+
+```liquid
+Called {{ model }} with {{ message_count }} messages; finished with {{ finish_reason }}.
+```
+
+- `model`, `message_count` — start.
+- `finish_reason` — finish.
+
+Conditional variant that stays readable while the span is still running:
+
+```liquid
+LLM {{ model }}{% if total_tokens %}: {{ total_tokens }} tokens{% endif %}{% if finish_reason %} -> {{ finish_reason }}{% endif %}
+```
+
+## AI SDK LLM (`ai-sdk:llm`)
+
+```liquid
+LLM {{ inputs["ai.model.id"] }}{% if inputs["ai.model.provider"] %} ({{ inputs["ai.model.provider"] }}){% endif %}{% if outputs["ai.response.text"] %} -> {{ outputs["ai.response.text"] | truncate: 60 }}{% endif %}
+```
+
+- `inputs["ai.model.id"]`, `inputs["ai.model.provider"]` — start (middleware).
+- `outputs["ai.response.text"]` — finish.
+
+## AI SDK agent (`ai-sdk:agent`)
+
+Middleware does not emit this span type today. Use a static label unless you emit it yourself:
+
+```liquid
+Agent run
+```
+
+## LangChain LLM (`langchain:llm`)
+
+```liquid
+LLM {{ inputs["langchain.model.name"] }}{% if outputs.content %} -> {{ outputs.content | truncate: 60 }}{% endif %}
+```
+
+- `inputs["langchain.model.name"]` — start.
+- `outputs.content` — finish.
+
+## LangChain agent (`langchain:agent`)
+
+Middleware does not emit this span type today. Use a static label unless you emit it yourself:
+
+```liquid
+Agent run
+```
+
+## Tool / function call
+
+```liquid
+Looked up order {{ order_id }}; status {{ status }}.
+```
+
+- `order_id` — start.
+- `status` — finish.
+
+Generic tool template with error flagging:
+
+```liquid
+Tool {{ tool_name }}{% if status %} -> {{ status }}{% endif %}{% if is_error %} (error){% endif %}
+```
+
+- `tool_name` — start.
+- `status`, `is_error` — finish.
+
+LangChain / AI SDK tool span (from `toolSchemas`, span type `langchain:tool:calculator`):
+
+```liquid
+Tool {{ inputs.toolName }}{% if inputs.input.expression %}: {{ inputs.input.expression }}{% endif %}{% if outputs.output %} -> {{ outputs.output | truncate: 60 }}{% endif %}
+```
+
+- `inputs.toolName`, `inputs.input.expression` — start.
+- `outputs.output` — finish.
+
+## Custom span (`withSpan`)
+
+Start field under `inputs` envelope:
+
+```liquid
+Example root: {{ inputs.example }}
+```
+
+String finish (wrapped as `result`):
+
+```liquid
+Normalized {{ inputs.rawLength }} chars{% if result %} -> {{ result | truncate: 60 }}{% endif %}
+```
+
+Object finish (fields at top level):
+
+```liquid
+Summary {{ wordCount }} words{% if inputs.normalizedLength %}, {{ inputs.normalizedLength }} chars{% endif %}{% if preview %}: {{ preview | truncate: 60 }}{% endif %}
+```
+
+- `inputs.example`, `inputs.rawLength`, `inputs.normalizedLength` — start (`withSpan` `inputs` option).
+- `result` — finish when callback returns a string/primitive.
+- `preview`, `wordCount` — finish when callback returns an object.
+
+## User message / turn
+
+```liquid
+User ({{ role }}): {{ content }}
+```
+
+- `role`, `content` — start.
+
+Turn with optional language and cancellation:
+
+```liquid
+{% if transcript %}User: {{ transcript }}{% else %}User turn{% endif %}{% if language %} ({{ language }}){% endif %}{% if status == "cancelled" %} -> cancelled{% endif %}
+```
+
+- `transcript`, `language`, `status` — finish.
+
+## Assistant message
+
+```liquid
+{{ content }}
+```
+
+- `content` — start. The visible assistant reply.
+
+## Session (nested objects + multiple optionals)
+
+```liquid
+Session {{ status }}{% if conversation.userMessages %}: {{ conversation.userMessages }} user, {{ conversation.assistantMessages }} assistant{% endif %}{% if metadata.closeReason %} ({{ metadata.closeReason }}){% endif %}
+```
+
+- `status`, `conversation.*`, `metadata.closeReason` — finish.
+- Note the nested dot paths: reach into `conversation` and `metadata` rather than printing the whole object.
+
+## Component metrics (STT / TTS)
+
+```liquid
+STT {{ model_name }}{% if metrics.audio_duration_ms %}: {{ metrics.audio_duration_ms }} ms audio{% endif %}{% if status %} -> {{ status }}{% endif %}
+```
+
+```liquid
+TTS {{ model_name }}{% if metrics.characters_count %}: {{ metrics.characters_count }} chars{% endif %}{% if status %} -> {{ status }}{% endif %}
+```
+
+- `model_name` — start.
+- `metrics.*`, `status` — finish.
+
+## Error
+
+```liquid
+{{ provider }} error{% if error.error_type %} {{ error.error_type }}{% endif %}{% if error.message %}: {{ error.message }}{% endif %}
+```
+
+- `error.error_type`, `error.message` — finish.
+
+## Source references
+
+- LiveKit production templates: `packages/livekit/src/schema.ts` (`LIVEKIT_*_TEMPLATE` constants).
+- LiveKit template tests: `packages/livekit/tests/schema.test.ts`.
+- Core schema type with the `template` field: `packages/core/src/tracing/span-schema.ts`.


### PR DESCRIPTION
## Summary
- Add `prefactor agent_instances agent_context <id>` to fetch debugging context JSON, with optional `--output` file write
- Improve `prefactor login` with `--base-url` and profile resolution so multi-environment credentials do not overwrite the default profile
- Document CLI changes and add skills for inspecting agent runs via CLI and writing span summary templates

## Commits
1. `feat(cli): add agent_instances agent_context command`
2. `feat(cli): resolve login profile by base URL`
3. `docs(cli): document agent_context and login profile behavior`
4. `skills: add inspect-agent-run and span summary template skills`

## Test plan
- [x] `bun test packages/cli/tests/cli.test.ts` (agent_context tests)
- [x] `bun test packages/cli/tests/login.test.ts` (login profile resolution tests)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an agent_context subcommand to export an agent instance’s debugging context, with optional JSON output to a file.

* **Documentation**
  * New RCA guide for inspecting agent runs with the CLI.
  * New guide and examples for writing span summary templates.
  * CLI README updated to list the agent_context command.

* **Tests**
  * Added CLI integration tests for agent_context export and file output.

* **Chores**
  * CLI package version bumped to 0.1.1.
  * Broadened core package compatibility across several packages and improved login URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->