### PR TITLE
[PRE-392] add instance purpose and quality schema support

### DIFF
--- a/.changeset/add-instance-purpose-and-quality-schema.md
+++ b/.changeset/add-instance-purpose-and-quality-schema.md
@@ -1,0 +1,5 @@
+---
+"@prefactor/core": minor
+---
+
+Add instance purpose and quality schema support to the core SDK. Agent instance registration now accepts an optional `purpose` field (`'live' | 'smoke_test' | 'eval'`), forwarded to the API with no SDK-imposed default. Agent schema versions now support an optional `quality_schema` field mirroring span type schema shape. Agent instances can be updated with a `quality_payload` via the new `updateInstance()` method on `AgentInstanceManager` and `updateAgentInstance()` on the transport.

--- a/packages/core/src/agent/instance-manager.ts
+++ b/packages/core/src/agent/instance-manager.ts
@@ -7,6 +7,11 @@ export type AgentInstanceManagerOptions = {
 
 type AgentInstanceStartOptions = AgentInstanceOptions;
 
+type AgentInstanceUpdateOptions = {
+  /** Quality evaluation payload for this instance (omit to keep current; null to clear). */
+  qualityPayload?: Record<string, unknown> | null;
+};
+
 /**
  * Coordinates agent instance lifecycle and schema registration for a transport.
  */
@@ -62,6 +67,16 @@ export class AgentInstanceManager {
 
   finishInstance(): void {
     this.transport.finishAgentInstance();
+  }
+
+  /**
+   * Updates the current agent instance with the given payload.
+   * Currently supports updating the quality_payload field.
+   */
+  updateInstance(options: AgentInstanceUpdateOptions = {}): void {
+    this.transport.updateAgentInstance({
+      qualityPayload: options.qualityPayload,
+    });
   }
 
   getAgentInstanceId(): string | null {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -12,6 +12,7 @@ export type PrefactorTransportOperation =
   | 'agent_register'
   | 'agent_start'
   | 'agent_finish'
+  | 'agent_update'
   | 'span_create'
   | 'span_finish'
   | 'shutdown';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,7 +112,7 @@ export {
   SpanType,
   type TokenUsage,
 } from './tracing/span.js';
-export type { AgentSchemaVersion, SpanTypeSchema } from './tracing/span-schema.js';
+export type { AgentSchemaVersion, QualitySchema, SpanTypeSchema } from './tracing/span-schema.js';
 export { type EndSpanOptions, type StartSpanOptions, Tracer } from './tracing/tracer.js';
 export { withSpan } from './tracing/with-span.js';
 export {
@@ -121,6 +121,7 @@ export {
   type AgentInstanceRegisterPayload,
   type AgentInstanceResponse,
   type AgentInstanceStartOptions,
+  type AgentInstanceUpdatePayload,
 } from './transport/http/agent-instance-client.js';
 export {
   AgentSpanClient,

--- a/packages/core/src/queue/actions.ts
+++ b/packages/core/src/queue/actions.ts
@@ -36,8 +36,15 @@ export type SpanFinishAction = {
 } & FinishSpanOptions &
   RetryableActionMetadata;
 
+export type AgentUpdateAction = {
+  type: 'agent_update';
+  /** Quality evaluation payload for this instance (omit to keep current; null to clear). */
+  qualityPayload?: Record<string, unknown> | null;
+} & RetryableActionMetadata;
+
 export type TransportAction =
   | AgentStartAction
   | AgentFinishAction
+  | AgentUpdateAction
   | SpanEndAction
   | SpanFinishAction;

--- a/packages/core/src/tracing/span-schema.ts
+++ b/packages/core/src/tracing/span-schema.ts
@@ -22,6 +22,23 @@ export interface SpanTypeSchema {
 }
 
 /**
+ * Schema definition for a quality evaluation, mirroring the shape of span type schemas.
+ * Rendered through the same template machinery as span schemas.
+ */
+export interface QualitySchema {
+  /** JSON Schema describing the quality payload shape. */
+  schema: JsonSchema;
+  /** Human-readable title. Defaults to 'quality' when omitted. */
+  title?: string;
+  /** Optional human-readable description. */
+  description?: string;
+  /** Liquid template for rendering the quality payload as a human-readable summary. */
+  template?: string;
+  /** Risk metadata describing data sensitivity for quality payloads. */
+  data_risk?: DataRisk;
+}
+
+/**
  * Agent schema version payload sent during agent instance registration.
  * Contains the set of span type schemas that define this agent's tracing contract.
  */
@@ -30,4 +47,6 @@ export interface AgentSchemaVersion {
   external_identifier: string;
   /** Array of span type schema definitions. */
   span_type_schemas: SpanTypeSchema[];
+  /** Optional quality schema for instance evaluations. */
+  quality_schema?: QualitySchema;
 }

--- a/packages/core/src/transport/http.ts
+++ b/packages/core/src/transport/http.ts
@@ -8,6 +8,7 @@ import { PrefactorFatalError, PrefactorShutdownError } from '../errors.js';
 import type {
   AgentFinishAction,
   AgentStartAction,
+  AgentUpdateAction,
   SpanEndAction,
   SpanFinishAction,
   TransportAction,
@@ -37,6 +38,8 @@ export type AgentInstanceOptions = {
   agentName?: string;
   /** Human-readable agent description. */
   agentDescription?: string;
+  /** Why this instance ran: 'live' for an actual agent run, 'smoke_test' for a pipeline check, or 'eval' for an evaluation run. Omit to let the API default to 'live'. */
+  purpose?: 'live' | 'smoke_test' | 'eval';
 };
 
 export type TransientFailureKind =
@@ -50,7 +53,12 @@ type HttpTransportOptions = {
   sdkHeaderEntry?: string;
 };
 
-type RetryableAction = AgentStartAction | AgentFinishAction | SpanEndAction | SpanFinishAction;
+type RetryableAction =
+  | AgentStartAction
+  | AgentFinishAction
+  | AgentUpdateAction
+  | SpanEndAction
+  | SpanFinishAction;
 type RetryTimerMetadata = {
   operation: PrefactorTransportOperation;
 };
@@ -82,6 +90,12 @@ export interface Transport {
   startAgentInstance(options?: AgentInstanceOptions): void;
 
   finishAgentInstance(): void;
+
+  /**
+   * Updates the agent instance with the given payload.
+   * Currently supports updating the quality_payload field.
+   */
+  updateAgentInstance(payload: { qualityPayload?: Record<string, unknown> | null }): void;
 
   registerSchema(schema: Record<string, unknown>): void;
 
@@ -130,6 +144,7 @@ export class HttpTransport implements Transport {
   private schemaRevision = 0;
   private agentInstanceId: string | null = null;
   private currentAgentRegisterIdempotencyKey: string | null = null;
+  private agentPurpose: 'live' | 'smoke_test' | 'eval' | undefined;
   private spanIdMap = new Map<string, string>();
   private pendingFinishes = new Map<string, SpanFinishAction>();
   private pendingChildren = new Map<string, SpanEndAction[]>();
@@ -212,6 +227,20 @@ export class HttpTransport implements Transport {
     this.assertUsable('agent_finish');
     this.enqueue({
       type: 'agent_finish',
+      idempotencyKey: createActionIdempotencyKey(),
+      retryAttempt: 0,
+    });
+  }
+
+  updateAgentInstance(payload: { qualityPayload?: Record<string, unknown> | null }): void {
+    if (this.fatalError || this.closed) {
+      return;
+    }
+
+    this.assertUsable('agent_update');
+    this.enqueue({
+      type: 'agent_update',
+      qualityPayload: payload.qualityPayload,
       idempotencyKey: createActionIdempotencyKey(),
       retryAttempt: 0,
     });
@@ -390,6 +419,9 @@ export class HttpTransport implements Transport {
       case 'agent_finish':
         await this.processAgentFinish(action);
         return;
+      case 'agent_update':
+        await this.processAgentUpdate(action);
+        return;
       case 'span_end':
         await this.processSpanCreate(action);
         return;
@@ -422,6 +454,15 @@ export class HttpTransport implements Transport {
       this.recordActionSuccess(action);
     } catch (error) {
       this.handleActionError('agent_finish', action, error);
+    }
+  }
+
+  private async processAgentUpdate(action: AgentUpdateAction): Promise<void> {
+    try {
+      await this.updateAgentInstanceHttp(action);
+      this.recordActionSuccess(action);
+    } catch (error) {
+      this.handleActionError('agent_update', action, error);
     }
   }
 
@@ -857,6 +898,10 @@ export class HttpTransport implements Transport {
       };
     }
 
+    if (this.agentPurpose) {
+      payload.purpose = this.agentPurpose;
+    }
+
     if (this.config.agentSchema) {
       payload.agent_schema_version = this.config.agentSchema;
     }
@@ -912,6 +957,9 @@ export class HttpTransport implements Transport {
     if (action.options?.agentDescription !== undefined) {
       this.config.agentDescription = action.options.agentDescription;
     }
+    if (action.options?.purpose !== undefined) {
+      this.agentPurpose = action.options.purpose;
+    }
 
     await this.ensureAgentRegistered();
     if (!this.agentInstanceId) {
@@ -948,6 +996,20 @@ export class HttpTransport implements Transport {
 
     this.agentInstanceId = null;
     this.currentAgentRegisterIdempotencyKey = null;
+  }
+
+  private async updateAgentInstanceHttp(action: AgentUpdateAction): Promise<void> {
+    if (!this.agentInstanceId) {
+      this.recordPartialTelemetry('Cannot update agent instance: not registered');
+      return;
+    }
+
+    await this.agentInstanceClient.update(this.agentInstanceId, {
+      details: {
+        quality_payload: action.qualityPayload,
+      },
+      idempotency_key: action.idempotencyKey,
+    });
   }
 
   private async sendSpan(action: SpanEndAction): Promise<void> {
@@ -1057,6 +1119,8 @@ function operationForAction(action: TransportAction): PrefactorTransportOperatio
       return 'agent_start';
     case 'agent_finish':
       return 'agent_finish';
+    case 'agent_update':
+      return 'agent_update';
     case 'span_end':
       return 'span_create';
     case 'span_finish':
@@ -1078,7 +1142,8 @@ function isAgentNotFoundFailure(
   if (
     operation !== 'agent_register' &&
     operation !== 'agent_start' &&
-    operation !== 'agent_finish'
+    operation !== 'agent_finish' &&
+    operation !== 'agent_update'
   ) {
     return false;
   }

--- a/packages/core/src/transport/http.ts
+++ b/packages/core/src/transport/http.ts
@@ -957,9 +957,7 @@ export class HttpTransport implements Transport {
     if (action.options?.agentDescription !== undefined) {
       this.config.agentDescription = action.options.agentDescription;
     }
-    if (action.options?.purpose !== undefined) {
-      this.agentPurpose = action.options.purpose;
-    }
+    this.agentPurpose = action.options?.purpose;
 
     await this.ensureAgentRegistered();
     if (!this.agentInstanceId) {

--- a/packages/core/src/transport/http/agent-instance-client.ts
+++ b/packages/core/src/transport/http/agent-instance-client.ts
@@ -5,6 +5,8 @@ import { ensureIdempotencyKey } from './idempotency.js';
 export type AgentInstanceRegisterPayload = {
   agent_id?: string;
   environment_id?: string;
+  /** Why this instance ran: 'live' for an actual agent run, 'smoke_test' for a pipeline check, or 'eval' for an evaluation run. Omit to let the API default to 'live'. */
+  purpose?: 'live' | 'smoke_test' | 'eval';
   agent_version?: {
     external_identifier: string;
     name: string;
@@ -28,6 +30,14 @@ export type AgentInstanceStartOptions = {
 export type AgentInstanceFinishOptions = {
   status?: 'complete' | 'failed' | 'cancelled';
   timestamp?: string;
+  idempotency_key?: string;
+};
+
+export type AgentInstanceUpdatePayload = {
+  details: {
+    /** Quality evaluation payload for this instance (omit to keep current; null to clear). */
+    quality_payload?: Record<string, unknown> | null;
+  };
   idempotency_key?: string;
 };
 
@@ -60,6 +70,16 @@ export class AgentInstanceClient {
     return this.httpClient.request(`/api/v1/agent_instance/${agentInstanceId}/finish`, {
       method: 'POST',
       body: { ...opts, idempotency_key: ensureIdempotencyKey(opts.idempotency_key) },
+    });
+  }
+
+  update(
+    agentInstanceId: string,
+    payload: AgentInstanceUpdatePayload
+  ): Promise<AgentInstanceResponse> {
+    return this.httpClient.request(`/api/v1/agent_instance/${agentInstanceId}`, {
+      method: 'PUT',
+      body: { ...payload, idempotency_key: ensureIdempotencyKey(payload.idempotency_key) },
     });
   }
 }

--- a/packages/core/tests/agent/instance-manager.test.ts
+++ b/packages/core/tests/agent/instance-manager.test.ts
@@ -13,6 +13,7 @@ class MockTransport implements Transport {
   startedInstances: AgentInstanceOptions[] = [];
   finishedInstances = 0;
   registeredSchemas: Record<string, unknown>[] = [];
+  updatedInstances: Array<{ qualityPayload?: Record<string, unknown> | null }> = [];
 
   emit(span: Span): void {
     this.emitted.push(span);
@@ -28,6 +29,10 @@ class MockTransport implements Transport {
 
   finishAgentInstance(): void {
     this.finishedInstances += 1;
+  }
+
+  updateAgentInstance(payload: { qualityPayload?: Record<string, unknown> | null }): void {
+    this.updatedInstances.push(payload);
   }
 
   registerSchema(schema: Record<string, unknown>): void {
@@ -151,5 +156,35 @@ describe('AgentInstanceManager', () => {
     const manager = new AgentInstanceManager(transport, {});
 
     await expect(manager.ensureTokenValid()).rejects.toThrow('bad token');
+  });
+
+  test('updateInstance forwards quality payload to transport', () => {
+    const transport = new MockTransport();
+    const manager = new AgentInstanceManager(transport, {});
+
+    manager.updateInstance({ qualityPayload: { score: 95 } });
+
+    expect(transport.updatedInstances).toHaveLength(1);
+    expect(transport.updatedInstances[0]).toEqual({ qualityPayload: { score: 95 } });
+  });
+
+  test('updateInstance forwards null quality payload to transport', () => {
+    const transport = new MockTransport();
+    const manager = new AgentInstanceManager(transport, {});
+
+    manager.updateInstance({ qualityPayload: null });
+
+    expect(transport.updatedInstances).toHaveLength(1);
+    expect(transport.updatedInstances[0]).toEqual({ qualityPayload: null });
+  });
+
+  test('updateInstance with no options sends undefined quality payload', () => {
+    const transport = new MockTransport();
+    const manager = new AgentInstanceManager(transport, {});
+
+    manager.updateInstance();
+
+    expect(transport.updatedInstances).toHaveLength(1);
+    expect(transport.updatedInstances[0]).toEqual({ qualityPayload: undefined });
   });
 });

--- a/packages/core/tests/transport/http-endpoints.test.ts
+++ b/packages/core/tests/transport/http-endpoints.test.ts
@@ -59,6 +59,84 @@ describe('HTTP endpoint clients', () => {
     );
   });
 
+  test('agent instance client includes purpose in register payload when provided', async () => {
+    const calls: RequestCall[] = [];
+    const httpClient = {
+      request: async <TResponse>(path: string, options: HttpRequestOptions = {}) => {
+        calls.push({ path, options });
+        return { details: { id: 'agent-instance-1' } } as TResponse;
+      },
+    };
+
+    const client = new AgentInstanceClient(httpClient);
+
+    await client.register({ purpose: 'eval' });
+
+    expect(calls[0].path).toBe('/api/v1/agent_instance/register');
+    expect((calls[0].options.body as Record<string, unknown>).purpose).toBe('eval');
+  });
+
+  test('agent instance client omits purpose from register payload when not provided', async () => {
+    const calls: RequestCall[] = [];
+    const httpClient = {
+      request: async <TResponse>(path: string, options: HttpRequestOptions = {}) => {
+        calls.push({ path, options });
+        return { details: { id: 'agent-instance-1' } } as TResponse;
+      },
+    };
+
+    const client = new AgentInstanceClient(httpClient);
+
+    await client.register({});
+
+    expect((calls[0].options.body as Record<string, unknown>).purpose).toBeUndefined();
+  });
+
+  test('agent instance client posts update to expected endpoint', async () => {
+    const calls: RequestCall[] = [];
+    const httpClient = {
+      request: async <TResponse>(path: string, options: HttpRequestOptions = {}) => {
+        calls.push({ path, options });
+        return { details: { id: 'agent-instance-1' } } as TResponse;
+      },
+    };
+
+    const client = new AgentInstanceClient(httpClient);
+
+    await client.update('agent-instance-1', {
+      details: { quality_payload: { score: 95 } },
+    });
+
+    expect(calls[0].path).toBe('/api/v1/agent_instance/agent-instance-1');
+    expect(calls[0].options.method).toBe('PUT');
+    expect(calls[0].options.body).toMatchObject({
+      details: { quality_payload: { score: 95 } },
+    });
+    expect((calls[0].options.body as Record<string, unknown>).idempotency_key).toMatch(
+      UUID_V4_REGEX
+    );
+  });
+
+  test('agent instance client update sends null quality_payload', async () => {
+    const calls: RequestCall[] = [];
+    const httpClient = {
+      request: async <TResponse>(path: string, options: HttpRequestOptions = {}) => {
+        calls.push({ path, options });
+        return { details: { id: 'agent-instance-1' } } as TResponse;
+      },
+    };
+
+    const client = new AgentInstanceClient(httpClient);
+
+    await client.update('agent-instance-1', {
+      details: { quality_payload: null },
+    });
+
+    expect(calls[0].options.body).toMatchObject({
+      details: { quality_payload: null },
+    });
+  });
+
   test('agent span client posts create and finish to expected endpoints', async () => {
     const calls: RequestCall[] = [];
     const httpClient = {

--- a/packages/core/tests/transport/http.test.ts
+++ b/packages/core/tests/transport/http.test.ts
@@ -502,4 +502,120 @@ describe('HttpTransport', () => {
     const finishPayload = JSON.parse(String(finishCall?.options?.body)) as Record<string, unknown>;
     expect(finishPayload.sensitive_encoding).toBe(true);
   });
+
+  test('forwards purpose to register payload when provided', async () => {
+    const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
+    globalThis.fetch = (async (url, options) => {
+      fetchCalls.push({ url: String(url), options });
+      if (String(url).endsWith('/agent_instance/register')) {
+        return new Response(JSON.stringify({ details: { id: 'agent-instance-1' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const transport = new HttpTransport(createConfig());
+    transport.startAgentInstance({ purpose: 'eval' });
+    await transport.close();
+
+    const registerPayload = JSON.parse(fetchCalls[0]?.options?.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(registerPayload.purpose).toBe('eval');
+  });
+
+  test('omits purpose from register payload when not provided', async () => {
+    const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
+    globalThis.fetch = (async (url, options) => {
+      fetchCalls.push({ url: String(url), options });
+      if (String(url).endsWith('/agent_instance/register')) {
+        return new Response(JSON.stringify({ details: { id: 'agent-instance-1' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const transport = new HttpTransport(createConfig());
+    transport.startAgentInstance();
+    await transport.close();
+
+    const registerPayload = JSON.parse(fetchCalls[0]?.options?.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(registerPayload.purpose).toBeUndefined();
+  });
+
+  test('sends update agent instance call with quality payload', async () => {
+    const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
+    globalThis.fetch = (async (url, options) => {
+      fetchCalls.push({ url: String(url), options });
+      if (String(url).endsWith('/agent_instance/register')) {
+        return new Response(JSON.stringify({ details: { id: 'agent-instance-1' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const transport = new HttpTransport(createConfig());
+    transport.startAgentInstance();
+    transport.updateAgentInstance({ qualityPayload: { score: 95, passed: true } });
+    await transport.close();
+
+    const updateCall = fetchCalls.find((call) =>
+      call.url.endsWith('/api/v1/agent_instance/agent-instance-1')
+    );
+    expect(updateCall).toBeDefined();
+    const updatePayload = JSON.parse(String(updateCall?.options?.body)) as Record<string, unknown>;
+    expect(updatePayload.details).toEqual({ quality_payload: { score: 95, passed: true } });
+  });
+
+  test('sends update agent instance call with null quality payload', async () => {
+    const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
+    globalThis.fetch = (async (url, options) => {
+      fetchCalls.push({ url: String(url), options });
+      if (String(url).endsWith('/agent_instance/register')) {
+        return new Response(JSON.stringify({ details: { id: 'agent-instance-1' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const transport = new HttpTransport(createConfig());
+    transport.startAgentInstance();
+    transport.updateAgentInstance({ qualityPayload: null });
+    await transport.close();
+
+    const updateCall = fetchCalls.find((call) =>
+      call.url.endsWith('/api/v1/agent_instance/agent-instance-1')
+    );
+    expect(updateCall).toBeDefined();
+    const updatePayload = JSON.parse(String(updateCall?.options?.body)) as Record<string, unknown>;
+    expect(updatePayload.details).toEqual({ quality_payload: null });
+  });
 });

--- a/packages/core/tests/transport/http.test.ts
+++ b/packages/core/tests/transport/http.test.ts
@@ -559,6 +559,43 @@ describe('HttpTransport', () => {
     expect(registerPayload.purpose).toBeUndefined();
   });
 
+  test('resets purpose to API default when second instance omits purpose', async () => {
+    const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
+    globalThis.fetch = (async (url, options) => {
+      fetchCalls.push({ url: String(url), options });
+      if (String(url).endsWith('/agent_instance/register')) {
+        return new Response(JSON.stringify({ details: { id: 'agent-instance-1' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const transport = new HttpTransport(createConfig());
+    // First instance with explicit purpose
+    transport.startAgentInstance({ purpose: 'eval' });
+    transport.finishAgentInstance();
+    // Second instance without purpose — should reset to undefined (API default)
+    transport.startAgentInstance();
+    await transport.close();
+
+    // The second register call should not have purpose set
+    const secondRegisterCall = fetchCalls.find(
+      (call, index) => call.url.endsWith('/agent_instance/register') && index > 0
+    );
+    expect(secondRegisterCall).toBeDefined();
+    const registerPayload = JSON.parse(String(secondRegisterCall?.options?.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(registerPayload.purpose).toBeUndefined();
+  });
+
   test('sends update agent instance call with quality payload', async () => {
     const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
     globalThis.fetch = (async (url, options) => {


### PR DESCRIPTION
Aligns the TypeScript core packages to support the new purpose and quality features of Prefactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `updateInstance()` capability to update an active agent instance’s quality evaluation payload, including the ability to clear it.
  * Added support for setting an agent instance “purpose” (`live`, `smoke_test`, `eval`) during registration.
  * Added optional quality schema metadata to agent configuration and exposed related public types.
* **Bug Fixes**
  * Improved consistent handling of `agent_update` 404 responses during transport processing.
* **Tests**
  * Expanded coverage for instance updates, purpose inclusion/omission, correct request serialization (including `null`), and idempotency key generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->