### PR TITLE
[PRE-421] Stop creating the agent deployment manually in the setup CLI

### DIFF
--- a/.changeset/stop-manual-setup-deployment.md
+++ b/.changeset/stop-manual-setup-deployment.md
@@ -1,0 +1,5 @@
+---
+"@prefactor/cli": patch
+---
+
+Stop creating agent deployments manually in `prefactor setup`. Setup now resolves an environment and creates a deployment-scoped token; the backend creates the deployment when the token is issued if one does not already exist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ Follow this process for all non-trivial changes:
 5. Make the smallest change necessary to satisfy the current requirement.
 6. Run targeted validation first.
 7. Run broader validation if the change affects shared behavior, public exports, build output, configuration, or cross-package integration.
-8. Do not treat the task as complete while relevant checks are failing.
+8. Add or update a changeset for every release-worthy package change (see Changesets).
+9. Do not treat the task as complete while relevant checks are failing.
 
 ## Architecture and package roles
 
@@ -216,6 +217,7 @@ Do not consider work complete until all applicable items below are true:
 - Relevant typecheck passes.
 - Relevant test targets pass.
 - Public API docs or README updates were made if public usage changed.
+- A changeset exists for each release-worthy package change, and `bunx @changesets/cli status --since=origin/main` succeeds.
 
 ## Desloppify after major changes
 After completing a significant change, run the `desloppify` skill to check for technical debt introduced by your changes specifically. Report back only issues that were brought in by this change, not pre-existing issues in the codebase. Ground all observations to the diff of what was modified in this branch - both committed and uncommitted.
@@ -228,8 +230,35 @@ If the user doesn't have the desloppify cli installed, refer to the `INSTALL.md`
 - Do not add speculative abstractions, future-only hooks, or placeholder implementations unless explicitly requested.
 - Do not write tests for behavior guaranteed by the type system (e.g., type narrowing, null checks, basic input validation). Focus tests on lifecycle behavior, correctness of side effects, and data validity.
 
+## Changesets
+This monorepo uses [changesets](https://github.com/changesets/changesets) for versioning and npm releases. CI fails PRs that change publishable packages without a changeset (`bun run changeset status --since=origin/main`).
+
+After changing any package under `packages/*` that should ship in a release:
+1. Add a changeset before considering the work done (and include it in the same PR / commit set when committing).
+2. Prefer writing a markdown file under `.changeset/` with a descriptive kebab-case name. Example:
+
+```md
+---
+"@prefactor/cli": patch
+---
+
+Short summary of the user-facing change. Explain why it matters, not just which files changed.
+```
+
+3. List every affected publishable package in the frontmatter. Use:
+   - `patch` for bug fixes, internal corrections, and non-breaking behavior tweaks
+   - `minor` for new backward-compatible features or APIs
+   - `major` for breaking changes
+4. If multiple packages changed in one task, include all of them in one changeset (or one changeset per coherent release unit).
+5. Verify with `bunx @changesets/cli status --since=origin/main` (or `bun run changeset status --since=origin/main` after install). It must report the expected bumps and must not error about missing changesets.
+6. Use an empty changeset (`bunx @changesets/cli add --empty`) only when package files changed but the change must not trigger a release. Say so explicitly in the PR summary.
+7. Do not run `changeset version` or `changeset publish` unless explicitly asked; release automation owns those steps.
+8. Intentional `@prefactor/cli` changesets also gate CLI binary releases. Dependency-only CLI bumps are not enough for a binary release.
+
+Docs-only, test-only, CI-only, or root tooling changes that do not alter publishable package contents usually do not need a changeset. When unsure, add a patch changeset for the touched package(s).
+
 ## Versioning
-When bumping versions, always check the lockfile and verify dependency changes are intentional. Run a full build after version bumps to ensure the change is correct.
+Package versions are bumped via changesets, not by hand-editing `package.json` in feature PRs. When versions are bumped (for example during a release PR), always check the lockfile and verify dependency changes are intentional. Run a full build after version bumps to ensure the change is correct.
 
 ## Creating new packages
 When creating a new provider package (e.g., for a new AI framework):

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -88,7 +88,7 @@ prefactor ping
 prefactor setup <agent_id>
 ```
 
-This verifies the selected profile can access the agent, selects the deployment for that agent, creates a deployment-scoped runtime API token, and prints shell-style setup values:
+This verifies the selected profile can access the agent, resolves an environment for that agent (from an existing deployment when available), creates a deployment-scoped runtime API token (which creates a deployment if needed), and prints shell-style setup values:
 
 ```bash
 PREFACTOR_API_URL=...

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander';
 import type { ApiClient } from '../api-client.js';
 import { AccountClient } from '../clients/account.js';
 import { AgentClient } from '../clients/agent.js';
-import { type AgentDeployment, AgentDeploymentClient } from '../clients/agent-deployment.js';
+import { AgentDeploymentClient } from '../clients/agent-deployment.js';
 import { ApiTokenClient } from '../clients/api-token.js';
 import { EnvironmentClient } from '../clients/environment.js';
 import { getAuthedContext } from './shared.js';
@@ -17,11 +17,11 @@ export function registerSetupCommand(program: Command): void {
       const { apiClient, baseUrl } = await getAuthedContext(this);
 
       await new AgentClient(apiClient).retrieve(agentId);
-      const deployment = await resolveAgentDeployment(apiClient, agentId);
+      const environmentId = await resolveEnvironmentId(apiClient, agentId);
       const tokenResponse = await new ApiTokenClient(apiClient).create({
         token_scope: 'agent_deployment',
         agent_id: agentId,
-        environment_id: deployment.environment_id,
+        environment_id: environmentId,
       });
 
       console.log(`PREFACTOR_API_URL=${baseUrl}`);
@@ -31,19 +31,16 @@ export function registerSetupCommand(program: Command): void {
     });
 }
 
-async function resolveAgentDeployment(
-  apiClient: ApiClient,
-  agentId: string
-): Promise<AgentDeployment> {
+async function resolveEnvironmentId(apiClient: ApiClient, agentId: string): Promise<string> {
   const deploymentResponse = await new AgentDeploymentClient(apiClient).list(agentId);
   const deployments = getListItems(deploymentResponse);
 
   if (deployments.length === 0) {
-    return createAgentDeployment(apiClient, agentId);
+    return resolveEnvironmentIdFromAccount(apiClient);
   }
 
   if (deployments.length === 1) {
-    return deployments[0];
+    return deployments[0].environment_id;
   }
 
   const deploymentsWithCurrentVersion = deployments.filter(
@@ -51,7 +48,7 @@ async function resolveAgentDeployment(
   );
 
   if (deploymentsWithCurrentVersion.length === 1) {
-    return deploymentsWithCurrentVersion[0];
+    return deploymentsWithCurrentVersion[0].environment_id;
   }
 
   throw new Error(
@@ -59,15 +56,12 @@ async function resolveAgentDeployment(
   );
 }
 
-async function createAgentDeployment(
-  apiClient: ApiClient,
-  agentId: string
-): Promise<AgentDeployment> {
+async function resolveEnvironmentIdFromAccount(apiClient: ApiClient): Promise<string> {
   const accountResponse = await new AccountClient(apiClient).list();
   const accounts = getListItems(accountResponse);
 
   if (accounts.length === 0) {
-    throw new Error('No accounts accessible to this profile; cannot create a deployment.');
+    throw new Error('No accounts accessible to this profile; cannot create a deployment token.');
   }
 
   const account = accounts[0];
@@ -78,17 +72,7 @@ async function createAgentDeployment(
     throw new Error(`No environments found for account ${account.id}; create one first.`);
   }
 
-  const environment = environments[0];
-  const createResponse = await new AgentDeploymentClient(apiClient).create({
-    agent_id: agentId,
-    environment_id: environment.id,
-  });
-
-  console.error(
-    `Created agent deployment for agent '${agentId}' in environment '${environment.name}' (${environment.id}) under account '${account.name}' (${account.id}).`
-  );
-
-  return createResponse.details;
+  return environments[0].id;
 }
 
 function getListItems<T>(response: { details?: T[]; summaries?: T[] }): T[] {

--- a/packages/cli/tests/setup.test.ts
+++ b/packages/cli/tests/setup.test.ts
@@ -310,7 +310,7 @@ describe('CLI setup command', () => {
     ]);
   });
 
-  test('creates a deployment when none exist and prints setup values', async () => {
+  test('resolves an environment and creates a deployment token when no deployments exist', async () => {
     const cwd = join(tempRoot, 'cwd');
     mkdirSync(cwd, { recursive: true });
     process.chdir(cwd);
@@ -350,16 +350,7 @@ describe('CLI setup command', () => {
       }
 
       if (path === '/api/v1/agent_deployment' && method === 'POST') {
-        expect(init?.body).toBe('{"details":{"agent_id":"agent_new","environment_id":"env_abc"}}');
-        return jsonResponse({
-          details: {
-            id: 'deployment_new',
-            agent_id: 'agent_new',
-            environment_id: 'env_abc',
-            account_id: 'account_abc',
-            current_version_id: null,
-          },
-        });
+        throw new Error('setup must not create an agent deployment manually');
       }
 
       if (path === '/api/v1/api_token' && method === 'POST') {
@@ -373,29 +364,24 @@ describe('CLI setup command', () => {
     }) as typeof fetch;
 
     const log = mock(() => {});
-    const errorLog = mock(() => {});
     const originalLog = console.log;
-    const originalError = console.error;
     console.log = log;
-    console.error = errorLog;
 
     try {
       await createCli('1.0.0').parseAsync(['node', 'prefactor', 'setup', 'agent_new']);
     } finally {
       console.log = originalLog;
-      console.error = originalError;
     }
 
-    expect(calls).toHaveLength(6);
+    expect(calls).toHaveLength(5);
     expect(new URL(calls[0].url).pathname).toBe('/api/v1/agent/agent_new');
     expect(new URL(calls[1].url).pathname).toBe('/api/v1/agent_deployment');
     expect(calls[1].init?.method).toBe('GET');
     expect(new URL(calls[2].url).pathname).toBe('/api/v1/account');
     expect(new URL(calls[3].url).pathname).toBe('/api/v1/environment');
-    expect(new URL(calls[4].url).pathname).toBe('/api/v1/agent_deployment');
+    expect(new URL(calls[4].url).pathname).toBe('/api/v1/api_token');
     expect(calls[4].init?.method).toBe('POST');
-    expect(new URL(calls[5].url).pathname).toBe('/api/v1/api_token');
-    expect(calls[5].init?.body).toBe(
+    expect(calls[4].init?.body).toBe(
       '{"details":{"token_scope":"agent_deployment","agent_id":"agent_new","environment_id":"env_abc"}}'
     );
 
@@ -404,14 +390,9 @@ describe('CLI setup command', () => {
     expect(output).toContain('PREFACTOR_API_TOKEN=runtime-token-new');
     expect(output).toContain('PREFACTOR_AGENT_ID=agent_new');
     expect(output).toContain('PREFACTOR_AGENT_IDENTIFIER=1.0.0');
-
-    const stderr = errorLog.mock.calls.flat().join('\n');
-    expect(stderr).toContain('Created agent deployment');
-    expect(stderr).toContain('env_abc');
-    expect(stderr).toContain('account_abc');
   });
 
-  test('throws when no accounts are accessible and does not create a deployment', async () => {
+  test('throws when no accounts are accessible and does not create a deployment token', async () => {
     const cwd = join(tempRoot, 'cwd');
     mkdirSync(cwd, { recursive: true });
     process.chdir(cwd);
@@ -454,7 +435,9 @@ describe('CLI setup command', () => {
 
     await expect(
       createCli('1.0.0').parseAsync(['node', 'prefactor', 'setup', 'agent_no_accounts'])
-    ).rejects.toThrow('No accounts accessible to this profile; cannot create a deployment.');
+    ).rejects.toThrow(
+      'No accounts accessible to this profile; cannot create a deployment token.'
+    );
 
     expect(paths).toEqual([
       'GET /api/v1/agent/agent_no_accounts',
@@ -463,7 +446,7 @@ describe('CLI setup command', () => {
     ]);
   });
 
-  test('throws when the account has no environments and does not create a deployment', async () => {
+  test('throws when the account has no environments and does not create a deployment token', async () => {
     const cwd = join(tempRoot, 'cwd');
     mkdirSync(cwd, { recursive: true });
     process.chdir(cwd);

--- a/packages/cli/tests/setup.test.ts
+++ b/packages/cli/tests/setup.test.ts
@@ -435,9 +435,7 @@ describe('CLI setup command', () => {
 
     await expect(
       createCli('1.0.0').parseAsync(['node', 'prefactor', 'setup', 'agent_no_accounts'])
-    ).rejects.toThrow(
-      'No accounts accessible to this profile; cannot create a deployment token.'
-    );
+    ).rejects.toThrow('No accounts accessible to this profile; cannot create a deployment token.');
 
     expect(paths).toEqual([
       'GET /api/v1/agent/agent_no_accounts',


### PR DESCRIPTION
This pull request stops the Prefactor CLI `setup` command from creating an agent deployment with a direct API call. Setup selects an environment and creates a deployment-scoped API token; the backend creates the agent deployment when it issues that token if no deployment exists.

This pull request also adds repository agent instructions so package changes include a changeset before a pull request opens.

## Test plan
- [x] `bun test packages/cli/tests/setup.test.ts`
- [x] `bunx @changesets/cli status --since=origin/main`
- [ ] Confirm setup with no existing deployment still returns setup values and creates a token without `POST /agent_deployment`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated CLI setup to resolve an existing environment and create a deployment-scoped runtime token.
  * Deployment creation is now handled automatically when the token is issued, when needed.
* **Bug Fixes**
  * Improved setup errors when no accessible accounts or environments are available.
* **Documentation**
  * Clarified the CLI setup flow and added release-process guidance for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->