### PR TITLE
fix: add repository metadata for npm provenance

### DIFF
--- a/.changeset/add-repository-for-npm-provenance.md
+++ b/.changeset/add-repository-for-npm-provenance.md
@@ -1,0 +1,11 @@
+---
+"@prefactor/ai": patch
+"@prefactor/claude": patch
+"@prefactor/cli": patch
+"@prefactor/core": patch
+"@prefactor/langchain": patch
+"@prefactor/livekit": patch
+"@prefactor/openclaw-prefactor-plugin": patch
+---
+
+Add package `repository` metadata so npm provenance validation succeeds on publish.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -29,6 +29,11 @@
   ],
   "author": "Prefactor",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prefactordev/typescript-sdk.git",
+    "directory": "packages/ai"
+  },
   "dependencies": {
     "@prefactor/pfid": "^0.1.0"
   },

--- a/packages/claude/package.json
+++ b/packages/claude/package.json
@@ -28,6 +28,11 @@
   ],
   "author": "Prefactor",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prefactordev/typescript-sdk.git",
+    "directory": "packages/claude"
+  },
   "dependencies": {
     "@prefactor/pfid": "^0.1.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,11 @@
   ],
   "author": "Prefactor",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prefactordev/typescript-sdk.git",
+    "directory": "packages/cli"
+  },
   "dependencies": {
     "@prefactor/core": "workspace:*",
     "@prefactor/pfid": "^0.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,11 @@
   ],
   "author": "Prefactor",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prefactordev/typescript-sdk.git",
+    "directory": "packages/core"
+  },
   "dependencies": {
     "@prefactor/pfid": "^0.1.0"
   },

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -27,6 +27,11 @@
   ],
   "author": "Prefactor",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prefactordev/typescript-sdk.git",
+    "directory": "packages/langchain"
+  },
   "dependencies": {
     "@prefactor/pfid": "^0.1.0"
   },

--- a/packages/livekit/package.json
+++ b/packages/livekit/package.json
@@ -27,6 +27,11 @@
   ],
   "author": "Prefactor",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prefactordev/typescript-sdk.git",
+    "directory": "packages/livekit"
+  },
   "peerDependencies": {
     "@prefactor/core": "^0.5.0",
     "@livekit/agents": "^1.0.0"

--- a/packages/openclaw-prefactor-plugin/package.json
+++ b/packages/openclaw-prefactor-plugin/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prefactordev/typescript-sdk"
+    "url": "git+https://github.com/prefactordev/typescript-sdk.git",
+    "directory": "packages/openclaw-prefactor-plugin"
   },
   "keywords": [
     "openclaw",


### PR DESCRIPTION
## Summary
- Adds `repository` (with monorepo `directory`) to all publishable packages so npm provenance validation can match `https://github.com/prefactordev/typescript-sdk`
- Unblocks the failed release publish that rejected `@prefactor/{ai,claude,cli,core,langchain,livekit}` with `E422` empty `repository.url`
- Includes a patch changeset; after merge, release CI will open a version PR, then publish on that merge

## Test plan
- [ ] CI passes on this PR (including `changeset status --since=origin/main`)
- [ ] Merge this PR to `main`
- [ ] Merge the follow-up `chore: version packages` PR from changesets
- [ ] Confirm Release npm Packages publishes the pending package versions without provenance `E422`
- [ ] Confirm `@prefactor/openclaw-prefactor-plugin@1.0.0` is skipped (already on npm) and no tag push failure blocks the job


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added repository metadata to published packages.
  * Improved package provenance validation for npm releases.
  * Updated package metadata to identify each package’s location within the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->