### PR TITLE
[PRE-445] Add named quality schema support to the TypeScript core SDK

### DIFF
--- a/.changeset/pre-445-named-quality-schemas.md
+++ b/.changeset/pre-445-named-quality-schemas.md
@@ -1,0 +1,16 @@
+---
+'@prefactor/core': major
+---
+
+Add named quality schema support. Replace the singular `quality_schema` / `quality_payload` API with named quality schemas and keyed payloads (PRE-445).
+
+- `QualitySchema` gains a required `name` field
+- `AgentSchemaVersion.quality_schema` → `quality_schemas: QualitySchema[]`
+- `AgentInstanceManager.updateInstance({ qualityPayload })` → `recordQuality({ name, payload })`
+- `AgentInstanceClient.update()` (PUT) → `recordQuality()` (POST to `/record_quality`)
+- `Transport.updateAgentInstance()` → `Transport.recordQuality()`
+- `AgentInstanceUpdatePayload` → `AgentInstanceRecordQualityPayload`
+- `AgentUpdateAction` → `AgentRecordQualityAction`
+- `PrefactorTransportOperation` `'agent_update'` → `'agent_record_quality'`
+
+A null payload removes the recorded value for that name. Unknown fields are dropped by the API, so a client left on the old single-payload shape writes nothing and gets no error.

--- a/packages/core/src/agent/instance-manager.ts
+++ b/packages/core/src/agent/instance-manager.ts
@@ -7,9 +7,11 @@ export type AgentInstanceManagerOptions = {
 
 type AgentInstanceStartOptions = AgentInstanceOptions;
 
-type AgentInstanceUpdateOptions = {
-  /** Quality evaluation payload for this instance (omit to keep current; null to clear). */
-  qualityPayload?: Record<string, unknown> | null;
+type AgentInstanceRecordQualityOptions = {
+  /** Quality schema name (key in the agent schema version quality_schemas). */
+  name: string;
+  /** Quality payload for this name, or null to remove the recorded payload. */
+  payload: Record<string, unknown> | null;
 };
 
 /**
@@ -70,12 +72,13 @@ export class AgentInstanceManager {
   }
 
   /**
-   * Updates the current agent instance with the given payload.
-   * Currently supports updating the quality_payload field.
+   * Records a quality payload on the agent instance for a named quality schema.
+   * A null payload removes the recorded value for that name.
    */
-  updateInstance(options: AgentInstanceUpdateOptions = {}): void {
-    this.transport.updateAgentInstance({
-      qualityPayload: options.qualityPayload,
+  recordQuality(options: AgentInstanceRecordQualityOptions): void {
+    this.transport.recordQuality({
+      name: options.name,
+      payload: options.payload,
     });
   }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -12,7 +12,7 @@ export type PrefactorTransportOperation =
   | 'agent_register'
   | 'agent_start'
   | 'agent_finish'
-  | 'agent_update'
+  | 'agent_record_quality'
   | 'span_create'
   | 'span_finish'
   | 'shutdown';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,7 +121,7 @@ export {
   type AgentInstanceRegisterPayload,
   type AgentInstanceResponse,
   type AgentInstanceStartOptions,
-  type AgentInstanceUpdatePayload,
+  type AgentInstanceRecordQualityPayload,
 } from './transport/http/agent-instance-client.js';
 export {
   AgentSpanClient,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,10 +118,10 @@ export { withSpan } from './tracing/with-span.js';
 export {
   AgentInstanceClient,
   type AgentInstanceFinishOptions,
+  type AgentInstanceRecordQualityPayload,
   type AgentInstanceRegisterPayload,
   type AgentInstanceResponse,
   type AgentInstanceStartOptions,
-  type AgentInstanceRecordQualityPayload,
 } from './transport/http/agent-instance-client.js';
 export {
   AgentSpanClient,

--- a/packages/core/src/queue/actions.ts
+++ b/packages/core/src/queue/actions.ts
@@ -36,15 +36,17 @@ export type SpanFinishAction = {
 } & FinishSpanOptions &
   RetryableActionMetadata;
 
-export type AgentUpdateAction = {
-  type: 'agent_update';
-  /** Quality evaluation payload for this instance (omit to keep current; null to clear). */
-  qualityPayload?: Record<string, unknown> | null;
+export type AgentRecordQualityAction = {
+  type: 'agent_record_quality';
+  /** Quality schema name (key in the agent schema version quality_schemas). */
+  name: string;
+  /** Quality payload for this name, or null to remove the recorded payload. */
+  payload: Record<string, unknown> | null;
 } & RetryableActionMetadata;
 
 export type TransportAction =
   | AgentStartAction
   | AgentFinishAction
-  | AgentUpdateAction
+  | AgentRecordQualityAction
   | SpanEndAction
   | SpanFinishAction;

--- a/packages/core/src/tracing/span-schema.ts
+++ b/packages/core/src/tracing/span-schema.ts
@@ -22,13 +22,20 @@ export interface SpanTypeSchema {
 }
 
 /**
- * Schema definition for a quality evaluation, mirroring the shape of span type schemas.
- * Rendered through the same template machinery as span schemas.
+ * Named schema definition for a quality evaluation.
+ *
+ * Each entry in `AgentSchemaVersion.quality_schemas` carries a name (the key
+ * used when recording quality payloads on an agent instance) alongside the
+ * JSON schema, optional display metadata, and data-risk fields.
+ *
+ * Rendered through the same template machinery as span type schemas.
  */
 export interface QualitySchema {
+  /** Schema name — the key used when recording quality payloads. */
+  name: string;
   /** JSON Schema describing the quality payload shape. */
   schema: JsonSchema;
-  /** Human-readable title. Defaults to 'quality' when omitted. */
+  /** Human-readable title. Defaults to `name` when omitted. */
   title?: string;
   /** Optional human-readable description. */
   description?: string;
@@ -47,6 +54,6 @@ export interface AgentSchemaVersion {
   external_identifier: string;
   /** Array of span type schema definitions. */
   span_type_schemas: SpanTypeSchema[];
-  /** Optional quality schema for instance evaluations. */
-  quality_schema?: QualitySchema;
+  /** Named quality schemas for instance evaluations. */
+  quality_schemas?: QualitySchema[];
 }

--- a/packages/core/src/transport/http.ts
+++ b/packages/core/src/transport/http.ts
@@ -7,8 +7,8 @@ import type {
 import { PrefactorFatalError, PrefactorShutdownError } from '../errors.js';
 import type {
   AgentFinishAction,
+  AgentRecordQualityAction,
   AgentStartAction,
-  AgentUpdateAction,
   SpanEndAction,
   SpanFinishAction,
   TransportAction,
@@ -56,7 +56,7 @@ type HttpTransportOptions = {
 type RetryableAction =
   | AgentStartAction
   | AgentFinishAction
-  | AgentUpdateAction
+  | AgentRecordQualityAction
   | SpanEndAction
   | SpanFinishAction;
 type RetryTimerMetadata = {
@@ -92,10 +92,13 @@ export interface Transport {
   finishAgentInstance(): void;
 
   /**
-   * Updates the agent instance with the given payload.
-   * Currently supports updating the quality_payload field.
+   * Records a quality payload on the agent instance for a named quality schema.
+   * A null payload removes the recorded value for that name.
    */
-  updateAgentInstance(payload: { qualityPayload?: Record<string, unknown> | null }): void;
+  recordQuality(payload: {
+    name: string;
+    payload: Record<string, unknown> | null;
+  }): void;
 
   registerSchema(schema: Record<string, unknown>): void;
 
@@ -232,15 +235,19 @@ export class HttpTransport implements Transport {
     });
   }
 
-  updateAgentInstance(payload: { qualityPayload?: Record<string, unknown> | null }): void {
+  recordQuality(payload: {
+    name: string;
+    payload: Record<string, unknown> | null;
+  }): void {
     if (this.fatalError || this.closed) {
       return;
     }
 
-    this.assertUsable('agent_update');
+    this.assertUsable('agent_record_quality');
     this.enqueue({
-      type: 'agent_update',
-      qualityPayload: payload.qualityPayload,
+      type: 'agent_record_quality',
+      name: payload.name,
+      payload: payload.payload,
       idempotencyKey: createActionIdempotencyKey(),
       retryAttempt: 0,
     });
@@ -419,8 +426,8 @@ export class HttpTransport implements Transport {
       case 'agent_finish':
         await this.processAgentFinish(action);
         return;
-      case 'agent_update':
-        await this.processAgentUpdate(action);
+      case 'agent_record_quality':
+        await this.processAgentRecordQuality(action);
         return;
       case 'span_end':
         await this.processSpanCreate(action);
@@ -457,12 +464,12 @@ export class HttpTransport implements Transport {
     }
   }
 
-  private async processAgentUpdate(action: AgentUpdateAction): Promise<void> {
+  private async processAgentRecordQuality(action: AgentRecordQualityAction): Promise<void> {
     try {
-      await this.updateAgentInstanceHttp(action);
+      await this.recordQualityHttp(action);
       this.recordActionSuccess(action);
     } catch (error) {
-      this.handleActionError('agent_update', action, error);
+      this.handleActionError('agent_record_quality', action, error);
     }
   }
 
@@ -996,16 +1003,15 @@ export class HttpTransport implements Transport {
     this.currentAgentRegisterIdempotencyKey = null;
   }
 
-  private async updateAgentInstanceHttp(action: AgentUpdateAction): Promise<void> {
+  private async recordQualityHttp(action: AgentRecordQualityAction): Promise<void> {
     if (!this.agentInstanceId) {
-      this.recordPartialTelemetry('Cannot update agent instance: not registered');
+      this.recordPartialTelemetry('Cannot record quality: agent instance not registered');
       return;
     }
 
-    await this.agentInstanceClient.update(this.agentInstanceId, {
-      details: {
-        quality_payload: action.qualityPayload,
-      },
+    await this.agentInstanceClient.recordQuality(this.agentInstanceId, {
+      name: action.name,
+      payload: action.payload,
       idempotency_key: action.idempotencyKey,
     });
   }
@@ -1117,8 +1123,8 @@ function operationForAction(action: TransportAction): PrefactorTransportOperatio
       return 'agent_start';
     case 'agent_finish':
       return 'agent_finish';
-    case 'agent_update':
-      return 'agent_update';
+    case 'agent_record_quality':
+      return 'agent_record_quality';
     case 'span_end':
       return 'span_create';
     case 'span_finish':
@@ -1141,7 +1147,7 @@ function isAgentNotFoundFailure(
     operation !== 'agent_register' &&
     operation !== 'agent_start' &&
     operation !== 'agent_finish' &&
-    operation !== 'agent_update'
+    operation !== 'agent_record_quality'
   ) {
     return false;
   }

--- a/packages/core/src/transport/http.ts
+++ b/packages/core/src/transport/http.ts
@@ -95,10 +95,7 @@ export interface Transport {
    * Records a quality payload on the agent instance for a named quality schema.
    * A null payload removes the recorded value for that name.
    */
-  recordQuality(payload: {
-    name: string;
-    payload: Record<string, unknown> | null;
-  }): void;
+  recordQuality(payload: { name: string; payload: Record<string, unknown> | null }): void;
 
   registerSchema(schema: Record<string, unknown>): void;
 
@@ -235,10 +232,7 @@ export class HttpTransport implements Transport {
     });
   }
 
-  recordQuality(payload: {
-    name: string;
-    payload: Record<string, unknown> | null;
-  }): void {
+  recordQuality(payload: { name: string; payload: Record<string, unknown> | null }): void {
     if (this.fatalError || this.closed) {
       return;
     }

--- a/packages/core/src/transport/http.ts
+++ b/packages/core/src/transport/http.ts
@@ -232,6 +232,14 @@ export class HttpTransport implements Transport {
     });
   }
 
+  /**
+   * Enqueues a record-quality action for the current agent instance.
+   *
+   * A null payload removes the recorded value for that name. The action
+   * is queued and retried like other transport actions.
+   *
+   * @param payload - Quality schema name and payload (or null to remove).
+   */
   recordQuality(payload: { name: string; payload: Record<string, unknown> | null }): void {
     if (this.fatalError || this.closed) {
       return;

--- a/packages/core/src/transport/http/agent-instance-client.ts
+++ b/packages/core/src/transport/http/agent-instance-client.ts
@@ -73,6 +73,16 @@ export class AgentInstanceClient {
     });
   }
 
+  /**
+   * Records a named quality payload on an agent instance.
+   *
+   * A null payload removes the recorded value for that name. Other names
+   * are left unchanged. An idempotency key is auto-generated when omitted.
+   *
+   * @param agentInstanceId - Backend agent instance ID.
+   * @param payload - Quality schema name and payload (or null to remove).
+   * @returns The API response containing the updated instance details.
+   */
   recordQuality(
     agentInstanceId: string,
     payload: AgentInstanceRecordQualityPayload

--- a/packages/core/src/transport/http/agent-instance-client.ts
+++ b/packages/core/src/transport/http/agent-instance-client.ts
@@ -33,11 +33,11 @@ export type AgentInstanceFinishOptions = {
   idempotency_key?: string;
 };
 
-export type AgentInstanceUpdatePayload = {
-  details: {
-    /** Quality evaluation payload for this instance (omit to keep current; null to clear). */
-    quality_payload?: Record<string, unknown> | null;
-  };
+export type AgentInstanceRecordQualityPayload = {
+  /** Quality schema name (key in the agent schema version quality_schemas). */
+  name: string;
+  /** Quality payload for this name, or null to remove the recorded payload. */
+  payload: Record<string, unknown> | null;
   idempotency_key?: string;
 };
 
@@ -73,13 +73,17 @@ export class AgentInstanceClient {
     });
   }
 
-  update(
+  recordQuality(
     agentInstanceId: string,
-    payload: AgentInstanceUpdatePayload
+    payload: AgentInstanceRecordQualityPayload
   ): Promise<AgentInstanceResponse> {
-    return this.httpClient.request(`/api/v1/agent_instance/${agentInstanceId}`, {
-      method: 'PUT',
-      body: { ...payload, idempotency_key: ensureIdempotencyKey(payload.idempotency_key) },
+    return this.httpClient.request(`/api/v1/agent_instance/${agentInstanceId}/record_quality`, {
+      method: 'POST',
+      body: {
+        name: payload.name,
+        payload: payload.payload,
+        idempotency_key: ensureIdempotencyKey(payload.idempotency_key),
+      },
     });
   }
 }

--- a/packages/core/tests/agent/instance-manager.test.ts
+++ b/packages/core/tests/agent/instance-manager.test.ts
@@ -13,7 +13,7 @@ class MockTransport implements Transport {
   startedInstances: AgentInstanceOptions[] = [];
   finishedInstances = 0;
   registeredSchemas: Record<string, unknown>[] = [];
-  updatedInstances: Array<{ qualityPayload?: Record<string, unknown> | null }> = [];
+  recordedQuality: Array<{ name: string; payload: Record<string, unknown> | null }> = [];
 
   emit(span: Span): void {
     this.emitted.push(span);
@@ -31,8 +31,8 @@ class MockTransport implements Transport {
     this.finishedInstances += 1;
   }
 
-  updateAgentInstance(payload: { qualityPayload?: Record<string, unknown> | null }): void {
-    this.updatedInstances.push(payload);
+  recordQuality(payload: { name: string; payload: Record<string, unknown> | null }): void {
+    this.recordedQuality.push(payload);
   }
 
   registerSchema(schema: Record<string, unknown>): void {
@@ -158,33 +158,23 @@ describe('AgentInstanceManager', () => {
     await expect(manager.ensureTokenValid()).rejects.toThrow('bad token');
   });
 
-  test('updateInstance forwards quality payload to transport', () => {
+  test('recordQuality forwards named quality payload to transport', () => {
     const transport = new MockTransport();
     const manager = new AgentInstanceManager(transport, {});
 
-    manager.updateInstance({ qualityPayload: { score: 95 } });
+    manager.recordQuality({ name: 'summary_quality', payload: { score: 95 } });
 
-    expect(transport.updatedInstances).toHaveLength(1);
-    expect(transport.updatedInstances[0]).toEqual({ qualityPayload: { score: 95 } });
+    expect(transport.recordedQuality).toHaveLength(1);
+    expect(transport.recordedQuality[0]).toEqual({ name: 'summary_quality', payload: { score: 95 } });
   });
 
-  test('updateInstance forwards null quality payload to transport', () => {
+  test('recordQuality forwards null payload to remove a named quality entry', () => {
     const transport = new MockTransport();
     const manager = new AgentInstanceManager(transport, {});
 
-    manager.updateInstance({ qualityPayload: null });
+    manager.recordQuality({ name: 'summary_quality', payload: null });
 
-    expect(transport.updatedInstances).toHaveLength(1);
-    expect(transport.updatedInstances[0]).toEqual({ qualityPayload: null });
-  });
-
-  test('updateInstance with no options sends undefined quality payload', () => {
-    const transport = new MockTransport();
-    const manager = new AgentInstanceManager(transport, {});
-
-    manager.updateInstance();
-
-    expect(transport.updatedInstances).toHaveLength(1);
-    expect(transport.updatedInstances[0]).toEqual({ qualityPayload: undefined });
+    expect(transport.recordedQuality).toHaveLength(1);
+    expect(transport.recordedQuality[0]).toEqual({ name: 'summary_quality', payload: null });
   });
 });

--- a/packages/core/tests/agent/instance-manager.test.ts
+++ b/packages/core/tests/agent/instance-manager.test.ts
@@ -165,7 +165,10 @@ describe('AgentInstanceManager', () => {
     manager.recordQuality({ name: 'summary_quality', payload: { score: 95 } });
 
     expect(transport.recordedQuality).toHaveLength(1);
-    expect(transport.recordedQuality[0]).toEqual({ name: 'summary_quality', payload: { score: 95 } });
+    expect(transport.recordedQuality[0]).toEqual({
+      name: 'summary_quality',
+      payload: { score: 95 },
+    });
   });
 
   test('recordQuality forwards null payload to remove a named quality entry', () => {

--- a/packages/core/tests/transport/http-endpoints.test.ts
+++ b/packages/core/tests/transport/http-endpoints.test.ts
@@ -92,7 +92,7 @@ describe('HTTP endpoint clients', () => {
     expect((calls[0].options.body as Record<string, unknown>).purpose).toBeUndefined();
   });
 
-  test('agent instance client posts update to expected endpoint', async () => {
+  test('agent instance client posts record_quality to expected endpoint', async () => {
     const calls: RequestCall[] = [];
     const httpClient = {
       request: async <TResponse>(path: string, options: HttpRequestOptions = {}) => {
@@ -103,21 +103,23 @@ describe('HTTP endpoint clients', () => {
 
     const client = new AgentInstanceClient(httpClient);
 
-    await client.update('agent-instance-1', {
-      details: { quality_payload: { score: 95 } },
+    await client.recordQuality('agent-instance-1', {
+      name: 'summary_quality',
+      payload: { score: 95 },
     });
 
-    expect(calls[0].path).toBe('/api/v1/agent_instance/agent-instance-1');
-    expect(calls[0].options.method).toBe('PUT');
+    expect(calls[0].path).toBe('/api/v1/agent_instance/agent-instance-1/record_quality');
+    expect(calls[0].options.method).toBe('POST');
     expect(calls[0].options.body).toMatchObject({
-      details: { quality_payload: { score: 95 } },
+      name: 'summary_quality',
+      payload: { score: 95 },
     });
     expect((calls[0].options.body as Record<string, unknown>).idempotency_key).toMatch(
       UUID_V4_REGEX
     );
   });
 
-  test('agent instance client update sends null quality_payload', async () => {
+  test('agent instance client record_quality sends null payload to remove entry', async () => {
     const calls: RequestCall[] = [];
     const httpClient = {
       request: async <TResponse>(path: string, options: HttpRequestOptions = {}) => {
@@ -128,12 +130,14 @@ describe('HTTP endpoint clients', () => {
 
     const client = new AgentInstanceClient(httpClient);
 
-    await client.update('agent-instance-1', {
-      details: { quality_payload: null },
+    await client.recordQuality('agent-instance-1', {
+      name: 'summary_quality',
+      payload: null,
     });
 
     expect(calls[0].options.body).toMatchObject({
-      details: { quality_payload: null },
+      name: 'summary_quality',
+      payload: null,
     });
   });
 

--- a/packages/core/tests/transport/http.test.ts
+++ b/packages/core/tests/transport/http.test.ts
@@ -596,7 +596,7 @@ describe('HttpTransport', () => {
     expect(registerPayload.purpose).toBeUndefined();
   });
 
-  test('sends update agent instance call with quality payload', async () => {
+  test('sends record_quality call with named quality payload', async () => {
     const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
     globalThis.fetch = (async (url, options) => {
       fetchCalls.push({ url: String(url), options });
@@ -615,18 +615,19 @@ describe('HttpTransport', () => {
 
     const transport = new HttpTransport(createConfig());
     transport.startAgentInstance();
-    transport.updateAgentInstance({ qualityPayload: { score: 95, passed: true } });
+    transport.recordQuality({ name: 'summary_quality', payload: { score: 95, passed: true } });
     await transport.close();
 
-    const updateCall = fetchCalls.find((call) =>
-      call.url.endsWith('/api/v1/agent_instance/agent-instance-1')
+    const recordCall = fetchCalls.find((call) =>
+      call.url.endsWith('/api/v1/agent_instance/agent-instance-1/record_quality')
     );
-    expect(updateCall).toBeDefined();
-    const updatePayload = JSON.parse(String(updateCall?.options?.body)) as Record<string, unknown>;
-    expect(updatePayload.details).toEqual({ quality_payload: { score: 95, passed: true } });
+    expect(recordCall).toBeDefined();
+    const recordPayload = JSON.parse(String(recordCall?.options?.body)) as Record<string, unknown>;
+    expect(recordPayload.name).toBe('summary_quality');
+    expect(recordPayload.payload).toEqual({ score: 95, passed: true });
   });
 
-  test('sends update agent instance call with null quality payload', async () => {
+  test('sends record_quality call with null payload to remove entry', async () => {
     const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
     globalThis.fetch = (async (url, options) => {
       fetchCalls.push({ url: String(url), options });
@@ -645,14 +646,15 @@ describe('HttpTransport', () => {
 
     const transport = new HttpTransport(createConfig());
     transport.startAgentInstance();
-    transport.updateAgentInstance({ qualityPayload: null });
+    transport.recordQuality({ name: 'summary_quality', payload: null });
     await transport.close();
 
-    const updateCall = fetchCalls.find((call) =>
-      call.url.endsWith('/api/v1/agent_instance/agent-instance-1')
+    const recordCall = fetchCalls.find((call) =>
+      call.url.endsWith('/api/v1/agent_instance/agent-instance-1/record_quality')
     );
-    expect(updateCall).toBeDefined();
-    const updatePayload = JSON.parse(String(updateCall?.options?.body)) as Record<string, unknown>;
-    expect(updatePayload.details).toEqual({ quality_payload: null });
+    expect(recordCall).toBeDefined();
+    const recordPayload = JSON.parse(String(recordCall?.options?.body)) as Record<string, unknown>;
+    expect(recordPayload.name).toBe('summary_quality');
+    expect(recordPayload.payload).toBeNull();
   });
 });


### PR DESCRIPTION
Replace the singular quality_schema/quality_payload API with the named quality_schemas/quality_payloads shape from PRE-429.

Schema changes:
- QualitySchema gains a required  field (the key used when recording quality payloads on an agent instance)
- AgentSchemaVersion.quality_schema → quality_schemas: QualitySchema[]

Transport changes:
- AgentInstanceClient.update() (PUT) → recordQuality() (POST to /api/v1/agent_instance/{id}/record_quality) with name + payload
- AgentInstanceUpdatePayload → AgentInstanceRecordQualityPayload
- AgentUpdateAction → AgentRecordQualityAction in the queue
- Transport.updateAgentInstance() → Transport.recordQuality()
- PrefactorTransportOperation 'agent_update' → 'agent_record_quality'
- AgentInstanceManager.updateInstance() → recordQuality({ name, payload })

A null payload removes the recorded value for that name. Other names are left unchanged. Unknown fields are dropped by the API, so a client left on the old single-payload shape writes nothing and gets no error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple named quality schemas.
  * Added named quality recording through a dedicated endpoint.
  * Added the ability to remove recorded quality values by submitting a null payload.
  * Unknown quality fields are silently ignored.

* **Breaking Changes**
  * Replaced generic instance updates with named quality-recording APIs.
  * Quality schema definitions now require a name and support arrays of schemas.
  * Renamed related quality-recording types and methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->