### PR TITLE
[PRE-477] Fix CLI install script 404 on macOS arm64

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -341,3 +341,43 @@ jobs:
           prerelease: false
           draft: false
           files: dist/cli/*
+
+  release-canary:
+    runs-on: ubuntu-latest
+    needs: [build, smoke-test]
+    if: always() && !cancelled() && !failure() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.build.result == 'success' && needs.smoke-test.result == 'success'
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ format('{0}-canary-release', github.repository) }}
+      cancel-in-progress: true
+    steps:
+      - name: Delete canary tag
+        run: gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/canary || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/cli
+          merge-multiple: true
+      - name: Generate checksums
+        run: |
+          cd dist/cli
+          sha256sum -- *.tar.gz *.zip > SHA256SUMS
+      - name: Publish canary release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: canary
+          target_commitish: ${{ github.sha }}
+          prerelease: true
+          make_latest: "false"
+          draft: false
+          files: dist/cli/*
+          body: |
+            Rolling canary build of the Prefactor CLI from `${{ github.sha }}` on `${{ github.ref_name }}`.
+
+            Install with:
+
+            ```bash
+            curl -fsSL https://raw.githubusercontent.com/prefactordev/typescript-sdk/main/scripts/install.sh | bash -s -- latest
+            ```

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -334,7 +334,7 @@ jobs:
           cd dist/cli
           sha256sum -- *.tar.gz *.zip > SHA256SUMS
       - name: Create stable release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.release.outputs.tag }}
           target_commitish: ${{ github.sha }}
@@ -353,7 +353,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Delete canary tag
-        run: gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/canary || true
+        run: |
+          output=$(gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/canary 2>&1) || {
+            echo "$output" | grep -q "404" || { echo "$output" >&2; exit 1; }
+          }
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v4
@@ -365,7 +368,7 @@ jobs:
           cd dist/cli
           sha256sum -- *.tar.gz *.zip > SHA256SUMS
       - name: Publish canary release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: canary
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           publish: bun run release:npm
           commit: 'chore: version packages'
           title: 'chore: version packages'
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -1,0 +1,209 @@
+name: Verify CLI Install
+
+# Runs the REAL install.sh / install.ps1 against the REAL GitHub release
+# URLs on every supported platform, after a release is published. This is
+# the closed loop that proves a release is actually installable end-to-end —
+# the existing unit tests mock the release server (PREFACTOR_RELEASE_*), so
+# they verify URL-string construction but cannot detect a release that 404s
+# in production (e.g. an empty npm release hijacking releases/latest, or a
+# draft canary with mismatched asset names).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to verify (e.g. v0.2.0 or canary).
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-install-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.matrix.outputs.skip }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      expected_tag: ${{ steps.matrix.outputs.expected_tag }}
+    steps:
+      - name: Resolve channels and build platform matrix
+        id: matrix
+        run: |
+          set -eu
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${{ github.event.release.tag_name }}"
+          fi
+
+          # Only CLI releases are verified: the rolling canary build, or a
+          # tagged vX.Y.Z stable release. Any other release (e.g. a stray npm
+          # package release) is skipped.
+          if [ "$tag" = "canary" ]; then
+            channels='["latest"]'
+            expected_tag="canary"
+          elif [[ "$tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            channels='["stable","pinned"]'
+            norm="$tag"
+            [[ "$norm" != v* ]] && norm="v$norm"
+            expected_tag="$norm"
+          else
+            echo "Skipping: release tag '$tag' is not a CLI release (canary or vX.Y.Z)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # All supported install conditions: macOS arm64/x64, Linux x64/arm64
+          # (glibc + musl), Windows x64/arm64.
+          platforms='[
+            {"platform":"linux-x64","os":"ubuntu-latest","script":"bash","musl":false,"asset":"prefactor-linux-x64.tar.gz"},
+            {"platform":"linux-arm64","os":"ubuntu-24.04-arm","script":"bash","musl":false,"asset":"prefactor-linux-arm64.tar.gz"},
+            {"platform":"linux-x64-musl","os":"ubuntu-latest","script":"bash","musl":true,"asset":"prefactor-linux-x64-musl.tar.gz"},
+            {"platform":"linux-arm64-musl","os":"ubuntu-24.04-arm","script":"bash","musl":true,"asset":"prefactor-linux-arm64-musl.tar.gz"},
+            {"platform":"darwin-arm64","os":"macos-latest","script":"bash","musl":false,"asset":"prefactor-darwin-arm64.tar.gz"},
+            {"platform":"darwin-x64","os":"macos-15-intel","script":"bash","musl":false,"asset":"prefactor-darwin-x64.tar.gz"},
+            {"platform":"windows-x64","os":"windows-latest","script":"pwsh","musl":false,"asset":"prefactor-windows-x64.zip"},
+            {"platform":"windows-arm64","os":"windows-11-arm","script":"pwsh","musl":false,"asset":"prefactor-windows-arm64.zip"}
+          ]'
+
+          matrix=$(jq -cn \
+            --argjson platforms "$platforms" \
+            --argjson channels "$channels" \
+            '[ $platforms[] as $p | $channels[] as $c | $p + {channel:$c} ]')
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "expected_tag=$expected_tag" >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: ${{ matrix.platform }} / ${{ matrix.channel }}
+    needs: prepare
+    if: needs.prepare.outputs.skip != 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    env:
+      EXPECTED_TAG: ${{ needs.prepare.outputs.expected_tag }}
+      CHANNEL: ${{ matrix.channel }}
+      ASSET: ${{ matrix.asset }}
+      REPO: prefactordev/typescript-sdk
+    steps:
+      - name: Wait for release assets to be resolvable (unix)
+        if: matrix.script == 'bash'
+        shell: bash
+        run: |
+          set -eu
+          case "$CHANNEL" in
+            stable) base="https://github.com/$REPO/releases/latest/download" ;;
+            pinned) base="https://github.com/$REPO/releases/download/$EXPECTED_TAG" ;;
+            latest) base="https://github.com/$REPO/releases/download/canary" ;;
+          esac
+          for url in "$base/$ASSET" "$base/SHA256SUMS"; do
+            code=0
+            for i in $(seq 1 60); do
+              code=$(curl -s -o /dev/null -w "%{http_code}" -L "$url" || true)
+              [ "$code" = "200" ] && break
+              echo "waiting for $url (HTTP $code) ..."
+              sleep 5
+            done
+            [ "$code" = "200" ] || { echo "Asset not resolvable: $url (HTTP $code)"; exit 1; }
+          done
+          echo "Assets resolvable under $base"
+
+      - name: Wait for release assets to be resolvable (windows)
+        if: matrix.script == 'pwsh'
+        shell: pwsh
+        run: |
+          switch ($env:CHANNEL) {
+            "stable" { $base = "https://github.com/$env:REPO/releases/latest/download" }
+            "pinned" { $base = "https://github.com/$env:REPO/releases/download/$env:EXPECTED_TAG" }
+            "latest" { $base = "https://github.com/$env:REPO/releases/download/canary" }
+          }
+          foreach ($url in @("$base/$env:ASSET", "$base/SHA256SUMS")) {
+            $code = 0
+            for ($i = 1; $i -le 60; $i++) {
+              try {
+                $resp = Invoke-WebRequest -Uri $url -Method Head -SkipHttpErrorCheck -ErrorAction Stop
+                $code = [int]$resp.StatusCode
+              } catch { $code = 0 }
+              if ($code -eq 200) { break }
+              Write-Host "waiting for $url (HTTP $code) ..."
+              Start-Sleep -Seconds 5
+            }
+            if ($code -ne 200) { Write-Error "Asset not resolvable: $url (HTTP $code)"; exit 1 }
+          }
+          Write-Host "Assets resolvable under $base"
+
+      - name: Install via install.sh (real release, glibc)
+        if: matrix.script == 'bash' && !matrix.musl
+        shell: bash
+        run: |
+          export HOME="$RUNNER_TEMP/prefactor-home"
+          rm -rf "$HOME"; mkdir -p "$HOME"
+          case "$CHANNEL" in
+            stable) arg="" ;;
+            latest) arg="latest" ;;
+            pinned) arg="$EXPECTED_TAG" ;;
+          esac
+          curl -fsSL "https://raw.githubusercontent.com/$REPO/$EXPECTED_TAG/scripts/install.sh" | bash -s -- $arg
+          "$HOME/.prefactor/bin/prefactor" --version
+          "$HOME/.prefactor/bin/prefactor" doctor | tee doctor.log
+          grep -q "resolvedTag: $EXPECTED_TAG" doctor.log
+
+      - name: Install via install.sh (real release, musl in alpine)
+        if: matrix.script == 'bash' && matrix.musl
+        shell: bash
+        run: |
+          docker run --rm \
+            -e HOME=/tmp/prefactor-home \
+            -e CHANNEL \
+            -e EXPECTED_TAG \
+            -e REPO \
+            alpine:3.22 \
+            sh -euxc '
+              apk add --no-cache bash curl tar ca-certificates libgcc libstdc++
+              rm -rf "$HOME"; mkdir -p "$HOME"
+              case "$CHANNEL" in
+                stable) arg="" ;;
+                latest) arg="latest" ;;
+                pinned) arg="$EXPECTED_TAG" ;;
+              esac
+              curl -fsSL "https://raw.githubusercontent.com/$REPO/$EXPECTED_TAG/scripts/install.sh" | bash -s -- $arg
+              "$HOME/.prefactor/bin/prefactor" --version
+              "$HOME/.prefactor/bin/prefactor" doctor | tee /tmp/doctor.log
+              grep -q "resolvedTag: $EXPECTED_TAG" /tmp/doctor.log
+            '
+
+      - name: Install via install.ps1 (real release)
+        if: matrix.script == 'pwsh'
+        shell: pwsh
+        run: |
+          $env:USERPROFILE = Join-Path $env:RUNNER_TEMP 'prefactor-home'
+          New-Item -ItemType Directory -Path $env:USERPROFILE -Force | Out-Null
+          $arg = switch ($env:CHANNEL) {
+            "stable" { "" }
+            "latest" { "latest" }
+            "pinned" { $env:EXPECTED_TAG }
+          }
+          $script = (irm "https://raw.githubusercontent.com/$env:REPO/$env:EXPECTED_TAG/scripts/install.ps1")
+          if ($arg) {
+            & ([scriptblock]::Create($script)) $arg
+          } else {
+            & ([scriptblock]::Create($script))
+          }
+          & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" --version
+          $doctor = & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" doctor 2>&1 | Out-String
+          Write-Host $doctor
+          if ($doctor -notmatch "resolvedTag: $env:EXPECTED_TAG") {
+            Write-Error "Expected resolvedTag '$env:EXPECTED_TAG' not found in doctor output"
+            exit 1
+          }

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -36,13 +36,16 @@ jobs:
     steps:
       - name: Resolve channels and build platform matrix
         id: matrix
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -eu
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
+            tag="$DISPATCH_TAG"
           else
-            tag="${{ github.event.release.tag_name }}"
+            tag="$RELEASE_TAG"
           fi
 
           # Only CLI releases are verified: the rolling canary build, or a
@@ -155,8 +158,11 @@ jobs:
             pinned) arg="$EXPECTED_TAG" ;;
           esac
           curl -fsSL "https://raw.githubusercontent.com/$REPO/$EXPECTED_TAG/scripts/install.sh" | bash -s -- $arg
-          "$HOME/.prefactor/bin/prefactor" --version
+          version_output="$("$HOME/.prefactor/bin/prefactor" --version)"
+          [ -n "$version_output" ] || { echo "Empty version output"; exit 1; }
+          echo "Installed version: $version_output"
           "$HOME/.prefactor/bin/prefactor" doctor | tee doctor.log
+          grep -q "channel: $CHANNEL" doctor.log
           grep -q "resolvedTag: $EXPECTED_TAG" doctor.log
 
       - name: Install via install.sh (real release, musl in alpine)
@@ -178,8 +184,11 @@ jobs:
                 pinned) arg="$EXPECTED_TAG" ;;
               esac
               curl -fsSL "https://raw.githubusercontent.com/$REPO/$EXPECTED_TAG/scripts/install.sh" | bash -s -- $arg
-              "$HOME/.prefactor/bin/prefactor" --version
+              version_output="$("$HOME/.prefactor/bin/prefactor" --version)"
+              [ -n "$version_output" ] || { echo "Empty version output"; exit 1; }
+              echo "Installed version: $version_output"
               "$HOME/.prefactor/bin/prefactor" doctor | tee /tmp/doctor.log
+              grep -q "channel: $CHANNEL" /tmp/doctor.log
               grep -q "resolvedTag: $EXPECTED_TAG" /tmp/doctor.log
             '
 
@@ -200,9 +209,15 @@ jobs:
           } else {
             & ([scriptblock]::Create($script))
           }
-          & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" --version
+          $versionOutput = & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" --version
+          if (-not $versionOutput) { Write-Error "Empty version output"; exit 1 }
+          Write-Host "Installed version: $versionOutput"
           $doctor = & "$env:USERPROFILE\.prefactor\bin\prefactor.exe" doctor 2>&1 | Out-String
           Write-Host $doctor
+          if ($doctor -notmatch "channel: $env:CHANNEL") {
+            Write-Error "Expected channel '$env:CHANNEL' not found in doctor output"
+            exit 1
+          }
           if ($doctor -notmatch "resolvedTag: $env:EXPECTED_TAG") {
             Write-Error "Expected resolvedTag '$env:EXPECTED_TAG' not found in doctor output"
             exit 1


### PR DESCRIPTION
## Problem

The documented default install 404s on every platform:

```bash
curl -fsSL https://raw.githubusercontent.com/prefactordev/typescript-sdk/main/scripts/install.sh | bash
```

`install.sh`'s default `stable` channel downloads from `…/releases/latest/download/<asset>` and `…/releases/latest/download/SHA256SUMS`. Right now `releases/latest` resolves to `@prefactor/ai@2.0.0` — an npm-package release with **zero binary assets** — so the asset and checksum both 404.

## Root cause

`release.yml` uses `changesets/action@v1`, which defaults to `createGithubReleases: true`. Every npm publish therefore creates a **non-prerelease, non-draft GitHub Release** (`@prefactor/ai@2.0.0`, `@prefactor/core@1.0.0`, …), each with no binary assets. These npm releases are created more recently than the CLI binary releases (`vX.Y.Z`), so GitHub's `releases/latest` points at an empty npm release instead of the latest CLI binary:

```
GET .../releases/latest/download/prefactor-darwin-arm64.tar.gz
  → 302 → .../download/@prefactor/ai@2.0.0/prefactor-darwin-arm64.tar.gz
  → 404
```

Every new npm publish re-breaks `stable`, even after a fresh CLI binary release lands.

## Fix

Set `createGithubReleases: false` on the changesets action. npm packages don't need GitHub releases; only `release-cli.yml`'s CLI binary release should own `releases/latest`, which is exactly what `install.sh` (and `release.ts`) expect for the `stable` channel.

This is a one-line, infra-only change.

## Verification

- `pinned` (e.g. `./scripts/install.sh v0.2.0`) already resolves correctly and is unaffected.
- After this merges, a one-time `gh release edit --prerelease` sweep of the existing `@prefactor/*` releases (out of scope for this PR) will make `releases/latest` fall back to `v0.2.0` and the default `stable` install will work on all platforms.
- No changeset needed: `changeset status` only gates publishable packages (`packages/*`); `.github/workflows/*.yml` isn't one.

PRE-477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated canary prerelease publishing after successful builds and smoke tests, including installation instructions for testing the latest changes.
* **Chores**
  * Updated release automation to publish packages and create version update pull requests without automatically creating GitHub releases through the package release workflow.
  * Updated stable release publishing for improved reliability.
* **Tests**
  * Added automated verification of published CLI releases across Linux, macOS, and Windows, including installation, version checks, and diagnostic output validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->