### PR TITLE
feat(ci): support "stable" keyword in verify-install workflow_dispatch

### DIFF
--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -102,7 +102,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     env:
       EXPECTED_TAG: ${{ needs.prepare.outputs.expected_tag }}
       CHANNEL: ${{ matrix.channel }}

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -14,7 +14,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to verify (e.g. v0.2.0 or canary).
+        description: Release tag to verify — a stable version (e.g. v0.2.0),
+          "canary" for the rolling build, or "stable" to resolve and test
+          whatever releases/latest currently points to.
         required: true
         type: string
 
@@ -39,6 +41,8 @@ jobs:
         env:
           DISPATCH_TAG: ${{ inputs.tag }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REPO: prefactordev/typescript-sdk
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
 
@@ -48,19 +52,24 @@ jobs:
             tag="$RELEASE_TAG"
           fi
 
-          # Only CLI releases are verified: the rolling canary build, or a
-          # tagged vX.Y.Z stable release. Any other release (e.g. a stray npm
-          # package release) is skipped.
+          # Only CLI releases are verified: the rolling canary build, a
+          # tagged vX.Y.Z stable release, or the special "stable" keyword
+          # which resolves whatever releases/latest currently points to.
+          # Any other release (e.g. a stray npm package release) is skipped.
           if [ "$tag" = "canary" ]; then
             channels='["latest"]'
             expected_tag="canary"
+          elif [ "$tag" = "stable" ]; then
+            tag="$(gh release view --repo "$REPO" latest --json tagName --jq .tagName)"
+            channels='["stable"]'
+            expected_tag="$tag"
           elif [[ "$tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             channels='["stable","pinned"]'
             norm="$tag"
             [[ "$norm" != v* ]] && norm="v$norm"
             expected_tag="$norm"
           else
-            echo "Skipping: release tag '$tag' is not a CLI release (canary or vX.Y.Z)."
+            echo "Skipping: release tag '$tag' is not a CLI release (canary, stable, or vX.Y.Z)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -60,7 +60,12 @@ jobs:
             channels='["latest"]'
             expected_tag="canary"
           elif [ "$tag" = "stable" ]; then
-            tag="$(gh release view --repo "$REPO" latest --json tagName --jq .tagName)"
+            tag="$(gh release view --repo "$REPO" --json tagName --jq .tagName)"
+            if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Skipping: releases/latest resolved to '$tag' which is not a CLI release (vX.Y.Z)."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             channels='["stable"]'
             expected_tag="$tag"
           elif [[ "$tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -109,6 +114,7 @@ jobs:
       CHANNEL: ${{ matrix.channel }}
       ASSET: ${{ matrix.asset }}
       REPO: prefactordev/typescript-sdk
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Wait for release assets to be resolvable (unix)
         if: matrix.script == 'bash'
@@ -116,7 +122,13 @@ jobs:
         run: |
           set -eu
           case "$CHANNEL" in
-            stable) base="https://github.com/$REPO/releases/latest/download" ;;
+            stable)
+              current_latest="$(gh release view --repo "$REPO" --json tagName --jq .tagName)"
+              if [ "$current_latest" != "$EXPECTED_TAG" ]; then
+                echo "releases/latest moved from $EXPECTED_TAG to $current_latest during run; aborting"
+                exit 1
+              fi
+              base="https://github.com/$REPO/releases/latest/download" ;;
             pinned) base="https://github.com/$REPO/releases/download/$EXPECTED_TAG" ;;
             latest) base="https://github.com/$REPO/releases/download/canary" ;;
           esac
@@ -137,7 +149,14 @@ jobs:
         shell: pwsh
         run: |
           switch ($env:CHANNEL) {
-            "stable" { $base = "https://github.com/$env:REPO/releases/latest/download" }
+            "stable" {
+              $currentLatest = gh release view --repo $env:REPO --json tagName --jq .tagName
+              if ($currentLatest -ne $env:EXPECTED_TAG) {
+                Write-Error "releases/latest moved from $env:EXPECTED_TAG to $currentLatest during run; aborting"
+                exit 1
+              }
+              $base = "https://github.com/$env:REPO/releases/latest/download"
+            }
             "pinned" { $base = "https://github.com/$env:REPO/releases/download/$env:EXPECTED_TAG" }
             "latest" { $base = "https://github.com/$env:REPO/releases/download/canary" }
           }


### PR DESCRIPTION
## Summary

Two changes to the Verify CLI Install workflow:

### 1. Fix: dynamic matrix syntax (`matrix.include`)

GitHub Actions expects the `matrix` field to be a map, not a sequence. The previous syntax:

```yaml
matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
```

passed a raw JSON array, causing:

> Error when evaluating `strategy` for job `verify`: A sequence was not expected

This broke all `verify-install` runs on main (no verify jobs were created). Fixed by switching to the standard dynamic-matrix pattern:

```yaml
matrix:
  include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
```

### 2. Feature: `stable` keyword for `workflow_dispatch`

Allow triggering the workflow with `tag=stable` to resolve whatever `releases/latest` currently points to and test only the `stable` channel (8 platform jobs, not 16). The prepare job calls `gh release view latest` to resolve the tag at runtime.

```bash
gh workflow run verify-install.yml -f tag=stable
```

PRE-477