### PR TITLE
fix(install): musl detection broken by pipefail in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,7 +97,7 @@ detect_libc() {
     return
   fi
 
-  if command_exists ldd && ldd --version 2>&1 | grep -qi musl; then
+  if command_exists ldd && { ldd --version 2>&1 || true; } | grep -qi musl; then
     printf 'musl'
     return
   fi


### PR DESCRIPTION
## Summary

`install.sh` has `set -euo pipefail` at the top. The musl detection in `detect_libc` runs:

```bash
ldd --version 2>&1 | grep -qi musl
```

In alpine (musl), `ldd --version` prints version info containing "musl" but **exits with code 1** (because `--version` is not a recognized option). With `pipefail` enabled, the pipeline returns exit code 1 (from `ldd`), even though `grep` successfully matches. So `detect_libc` falls through to `glibc`, downloads the wrong binary variant, and the binary fails with:

```
cannot execute: required file not found
```

**Impact:** Any user on a musl-based system (alpine, etc.) running `install.sh` downloads the glibc binary instead of the musl binary.

**Fix:** Wrap `ldd --version` in `{ ... || true; }` so its non-zero exit status does not propagate through `pipefail`:

```bash
if command_exists ldd && { ldd --version 2>&1 || true; } | grep -qi musl; then
```

**Discovered by** the `verify-install` workflow's musl/alpine jobs, which downloaded `prefactor-linux-x64.tar.gz` (glibc) instead of `prefactor-linux-x64-musl.tar.gz` inside an alpine container.

The TypeScript CLI (`platform.ts`) is unaffected — it uses Node.js's `process.report.header.glibcVersionRuntime` for detection, not a shell pipeline.

PRE-477