### PR TITLE
fix(ci): fetch install scripts from main, not the release tag

### DIFF
--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -186,7 +186,7 @@ jobs:
             latest) arg="latest" ;;
             pinned) arg="$EXPECTED_TAG" ;;
           esac
-          curl -fsSL "https://raw.githubusercontent.com/$REPO/$EXPECTED_TAG/scripts/install.sh" | bash -s -- $arg
+          curl -fsSL "https://raw.githubusercontent.com/$REPO/main/scripts/install.sh" | bash -s -- $arg
           version_output="$("$HOME/.prefactor/bin/prefactor" --version)"
           [ -n "$version_output" ] || { echo "Empty version output"; exit 1; }
           echo "Installed version: $version_output"
@@ -212,7 +212,7 @@ jobs:
                 latest) arg="latest" ;;
                 pinned) arg="$EXPECTED_TAG" ;;
               esac
-              curl -fsSL "https://raw.githubusercontent.com/$REPO/$EXPECTED_TAG/scripts/install.sh" | bash -s -- $arg
+              curl -fsSL "https://raw.githubusercontent.com/$REPO/main/scripts/install.sh" | bash -s -- $arg
               version_output="$("$HOME/.prefactor/bin/prefactor" --version)"
               [ -n "$version_output" ] || { echo "Empty version output"; exit 1; }
               echo "Installed version: $version_output"
@@ -232,7 +232,7 @@ jobs:
             "latest" { "latest" }
             "pinned" { $env:EXPECTED_TAG }
           }
-          $script = (irm "https://raw.githubusercontent.com/$env:REPO/$env:EXPECTED_TAG/scripts/install.ps1")
+          $script = (irm "https://raw.githubusercontent.com/$env:REPO/main/scripts/install.ps1")
           if ($arg) {
             & ([scriptblock]::Create($script)) $arg
           } else {


### PR DESCRIPTION
## Summary

The verify-install workflow pinned install scripts to the release tag (`$EXPECTED_TAG`), but the musl detection fix in `install.sh` (PR #64) only exists on `main` — the `v0.2.0` tag still has the old buggy `detect_libc`. This made it impossible to verify fixes against already-published releases.

Switch to fetching from `main` so the current install scripts are tested against published release assets. This is the right tradeoff for a verification workflow: CI already tests `install.sh` regressions on every push, so `verify-install`'s unique value is testing published releases with the **current** installer.

PRE-477