### PR TITLE
fix(release): accept 422 when deleting non-existent canary tag

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -355,7 +355,7 @@ jobs:
       - name: Delete canary tag
         run: |
           output=$(gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/canary 2>&1) || {
-            echo "$output" | grep -q "404" || { echo "$output" >&2; exit 1; }
+            echo "$output" | grep -qE "404|422|Reference does not exist" || { echo "$output" >&2; exit 1; }
           }
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -355,7 +355,7 @@ jobs:
       - name: Delete canary tag
         run: |
           output=$(gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/canary 2>&1) || {
-            echo "$output" | grep -qE "404|422|Reference does not exist" || { echo "$output" >&2; exit 1; }
+            echo "$output" | grep -q "Reference does not exist" || { echo "$output" >&2; exit 1; }
           }
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The GitHub API returns **HTTP 422** (not 404) when deleting a git ref that doesn't exist:

```json
{"message":"Reference does not exist","status":"422"}
```

The hardened tag deletion from commit `7837654` only allowed `404` through, so the **first canary run** (when no `canary` tag exists yet) always failed at the "Delete canary tag" step — preventing the canary release from ever being published.

This is why `releases/download/canary/...` has been 404ing: the canary release was never created because every `release-canary` job failed at tag deletion.

**Fix:** Accept both `404` and `422` (and the `"Reference does not exist"` message) as expected when the tag is absent.

**Verified locally:**
```
output: {"message":"Reference does not exist","status":"422"}
MATCHED — would continue
```

PRE-477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow reliability by treating already-missing canary tags as successful cleanup conditions.
  * Unexpected errors during tag deletion continue to fail the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->