### PR TITLE
[PRE-503] report runtime environment at agent registration

### DIFF
--- a/.changeset/report-runtime-environment.md
+++ b/.changeset/report-runtime-environment.md
@@ -2,4 +2,4 @@
 "@prefactor/core": minor
 ---
 
-Report runtime environment at agent registration. The SDK now automatically populates the optional `runtime_environment` field of `agent_version` with `prefactor_sdk` (the Prefactor packages in use), `agent_sdk` (upstream adaptor packages from the SDK header chain), `runtime` (the JavaScript runtime and version, e.g. `node@22.12.0` or `bun@1.2.3`), and `os` (the host platform). No user configuration is required.
+Report runtime environment at agent registration. The SDK now automatically populates the optional `runtime_environment` field of `agent_version` with `prefactor_sdk` (the core SDK `@prefactor/core@<version>` entry), `agent_sdk` (upstream adaptor packages from the SDK header chain), `runtime` (the JavaScript runtime and version, e.g. `node@22.12.0` or `bun@1.2.3`), and `os` (the host platform). No user configuration is required.

--- a/.changeset/report-runtime-environment.md
+++ b/.changeset/report-runtime-environment.md
@@ -1,0 +1,5 @@
+---
+"@prefactor/core": minor
+---
+
+Report runtime environment at agent registration. The SDK now automatically populates the optional `runtime_environment` field of `agent_version` with `prefactor_sdk` (the Prefactor packages in use), `agent_sdk` (upstream adaptor packages from the SDK header chain), `runtime` (the JavaScript runtime and version, e.g. `node@22.12.0` or `bun@1.2.3`), and `os` (the host platform). No user configuration is required.

--- a/packages/ai/tests/init.test.ts
+++ b/packages/ai/tests/init.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@prefactor/core';
 import {
   createSdkHeaderFetchRecorder,
-  expectRuntimeMetadataOmitted,
+  expectRuntimeEnvironment,
   expectSdkHeaderHeaders,
 } from '../../core/tests/shared/sdk-header.js';
 import { init, shutdown, withSpan } from '../src/init.js';
@@ -304,7 +304,7 @@ describe('ai init schema registration', () => {
     expect(finishCalls).toBe(1);
   });
 
-  test('sends adapter sdk header for package init and omits runtime metadata body fields', async () => {
+  test('sends adapter sdk header and runtime environment for package init', async () => {
     const recorder = createSdkHeaderFetchRecorder({ includeSpanResponses: true });
     globalThis.fetch = recorder.fetch;
 
@@ -320,7 +320,7 @@ describe('ai init schema registration', () => {
     await shutdown();
 
     expectSdkHeaderHeaders(recorder.getRegisterHeaders(), AI_SDK_HEADER_ENTRY);
-    expectRuntimeMetadataOmitted(recorder.getRegisterPayload());
+    expectRuntimeEnvironment(recorder.getRegisterPayload(), [AI_SDK_HEADER_ENTRY]);
   });
 
   test('sends adapter sdk header for the core provider path', async () => {

--- a/packages/claude/tests/provider.test.ts
+++ b/packages/claude/tests/provider.test.ts
@@ -3,7 +3,7 @@ import type { Query } from '@anthropic-ai/claude-agent-sdk';
 import { getClient, init as initCore } from '@prefactor/core';
 import {
   createSdkHeaderFetchRecorder,
-  expectRuntimeMetadataOmitted,
+  expectRuntimeEnvironment,
   expectSdkHeaderHeaders,
 } from '../../core/tests/shared/sdk-header.js';
 import { DEFAULT_CLAUDE_AGENT_SCHEMA, PrefactorClaude } from '../src/index.js';
@@ -225,7 +225,7 @@ describe('PrefactorClaude', () => {
     expect((provider as any).runtimeController).toBeNull();
   });
 
-  test('sends adapter sdk header for the core provider path and omits runtime metadata fields', async () => {
+  test('sends adapter sdk header and runtime environment for the core provider path', async () => {
     const recorder = createSdkHeaderFetchRecorder();
     globalThis.fetch = recorder.fetch;
 
@@ -241,6 +241,6 @@ describe('PrefactorClaude', () => {
     await prefactor.shutdown();
 
     expectSdkHeaderHeaders(recorder.getRegisterHeaders(), CLAUDE_SDK_HEADER_ENTRY);
-    expectRuntimeMetadataOmitted(recorder.getRegisterPayload());
+    expectRuntimeEnvironment(recorder.getRegisterPayload(), [CLAUDE_SDK_HEADER_ENTRY]);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,7 @@ export {
   type TerminationCallback,
   TerminationMonitor,
 } from './monitoring/termination-monitor.js';
+export { buildRuntimeEnvironment, type RuntimeEnvironment } from './runtime-environment.js';
 export {
   type JsonSchema,
   normalizeAgentToolSchemas,

--- a/packages/core/src/runtime-environment.ts
+++ b/packages/core/src/runtime-environment.ts
@@ -1,0 +1,72 @@
+import { PACKAGE_NAME, PACKAGE_VERSION } from './version.js';
+
+/**
+ * Runtime environment metadata reported at agent registration.
+ *
+ * Mirrors the `runtime_environment` field of the Prefactor API's
+ * `agent_version` payload.
+ */
+export type RuntimeEnvironment = {
+  /** Upstream agent framework packages (e.g. `["@prefactor/langchain@2.0.0"]`). */
+  agent_sdk: string[];
+  /** Host operating system name (e.g. `"linux"`, `"darwin"`, `"windows"`). */
+  os: string;
+  /** Prefactor SDK packages in use (e.g. `["@prefactor/core@1.0.0"]`). */
+  prefactor_sdk: string[];
+  /** JavaScript runtime and version (e.g. `"node@22.12.0"`, `"bun@1.2.3"`). */
+  runtime: string;
+};
+
+/**
+ * Builds the `runtime_environment` object for `agent_version` registration.
+ *
+ * Parses `sdkHeaderEntry` (a space-separated list of `"pkg@ver"` tokens set by
+ * upstream adaptors) into `agent_sdk` entries, stripping the core SDK
+ * self-entry. Always includes `prefactor_sdk`, `os`, and `runtime`.
+ *
+ * @param sdkHeaderEntry - Space-separated SDK header string set by upstream
+ *   adaptors (e.g. `"@prefactor/langchain@2.0.0"`). The core self-entry
+ *   (`@prefactor/core@...`) is automatically stripped from `agent_sdk`.
+ * @returns Runtime environment metadata for the `agent_version` payload.
+ */
+export function buildRuntimeEnvironment(sdkHeaderEntry?: string): RuntimeEnvironment {
+  return {
+    agent_sdk: parseAgentSdk(sdkHeaderEntry),
+    os: detectOs(),
+    prefactor_sdk: [`${PACKAGE_NAME}@${PACKAGE_VERSION}`],
+    runtime: detectRuntime(),
+  };
+}
+
+function parseAgentSdk(sdkHeaderEntry: string | undefined): string[] {
+  if (!sdkHeaderEntry) {
+    return [];
+  }
+
+  return sdkHeaderEntry
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0 && !token.startsWith(`${PACKAGE_NAME}@`));
+}
+
+function detectOs(): string {
+  const platform = process.platform;
+  return platform === 'win32' ? 'windows' : platform;
+}
+
+function detectRuntime(): string {
+  const globalObject = globalThis as {
+    Bun?: { version?: string };
+    Deno?: { version?: { deno?: string } };
+  };
+
+  if (typeof globalObject.Bun?.version === 'string') {
+    return `bun@${globalObject.Bun.version}`;
+  }
+
+  if (typeof globalObject.Deno?.version?.deno === 'string') {
+    return `deno@${globalObject.Deno.version.deno}`;
+  }
+
+  return `node@${process.versions.node}`;
+}

--- a/packages/core/src/transport/http.ts
+++ b/packages/core/src/transport/http.ts
@@ -15,6 +15,7 @@ import type {
 } from '../queue/actions.js';
 import { InMemoryQueue } from '../queue/in-memory-queue.js';
 import { TaskExecutor } from '../queue/task-executor.js';
+import { buildRuntimeEnvironment } from '../runtime-environment.js';
 import { buildSpanResultPayload } from '../tracing/result-payload.js';
 import type { Span } from '../tracing/span.js';
 import { getLogger } from '../utils/logging.js';
@@ -135,6 +136,7 @@ export class HttpTransport implements Transport {
   private readonly agentSpanClient: AgentSpanClient;
   private readonly httpClient: HttpClient;
   private readonly onFatalError?: (error: PrefactorFatalError) => void;
+  private readonly sdkHeaderEntry: string | undefined;
   private readonly retryTimers = new Map<ReturnType<typeof setTimeout>, RetryTimerMetadata>();
   private readonly transientFailureCounts = new Map<string, number>();
   private previousAgentSchema: string | null = null;
@@ -168,6 +170,7 @@ export class HttpTransport implements Transport {
     this.agentInstanceClient = new AgentInstanceClient(httpClient);
     this.agentSpanClient = new AgentSpanClient(httpClient);
     this.onFatalError = resolvedOptions.failureHandling?.onFatalError;
+    this.sdkHeaderEntry = resolvedOptions.sdkHeaderEntry;
     this.latestAgentIdentifier = config.agentIdentifier;
     this.taskExecutor = new TaskExecutor(this.actionQueue, this.processAction, {
       workerCount: 1,
@@ -904,6 +907,7 @@ export class HttpTransport implements Transport {
         external_identifier: this.config.agentIdentifier,
         name: this.config.agentName || 'Agent',
         description: this.config.agentDescription || '',
+        runtime_environment: buildRuntimeEnvironment(this.sdkHeaderEntry),
       };
     }
 

--- a/packages/core/src/transport/http/agent-instance-client.ts
+++ b/packages/core/src/transport/http/agent-instance-client.ts
@@ -1,3 +1,4 @@
+import type { RuntimeEnvironment } from '../../runtime-environment.js';
 import type { AgentSchemaVersion } from '../../tracing/span-schema.js';
 import type { HttpRequester } from './http-client.js';
 import { ensureIdempotencyKey } from './idempotency.js';
@@ -11,6 +12,7 @@ export type AgentInstanceRegisterPayload = {
     external_identifier: string;
     name: string;
     description: string;
+    runtime_environment?: RuntimeEnvironment;
   };
   agent_schema_version?: AgentSchemaVersion;
   idempotency_key?: string;

--- a/packages/core/tests/create-core.test.ts
+++ b/packages/core/tests/create-core.test.ts
@@ -6,7 +6,7 @@ import { withSpan } from '../src/tracing/with-span.js';
 import { PACKAGE_NAME, PACKAGE_VERSION } from '../src/version.js';
 import {
   createSdkHeaderFetchRecorder,
-  expectRuntimeMetadataOmitted,
+  expectRuntimeEnvironment,
   expectSdkHeaderHeaders,
 } from './shared/sdk-header.js';
 
@@ -118,7 +118,7 @@ describe('createCore', () => {
       const payload = recorder.getRegisterPayload();
 
       expect(headers.get('X-Prefactor-SDK')).toBe(CORE_SDK_HEADER_ENTRY);
-      expectRuntimeMetadataOmitted(payload);
+      expectRuntimeEnvironment(payload);
     } finally {
       if (!isShutdown) {
         await core.shutdown();
@@ -147,6 +147,7 @@ describe('createCore', () => {
       isShutdown = true;
 
       expectSdkHeaderHeaders(recorder.getRegisterHeaders(), 'prefactor/ai@0.3.1');
+      expectRuntimeEnvironment(recorder.getRegisterPayload(), ['@prefactor/ai@0.3.1']);
     } finally {
       if (!isShutdown) {
         await core.shutdown();

--- a/packages/core/tests/runtime-environment.test.ts
+++ b/packages/core/tests/runtime-environment.test.ts
@@ -16,7 +16,7 @@ describe('buildRuntimeEnvironment', () => {
 
   test('runtime identifies the JavaScript runtime', () => {
     const result = buildRuntimeEnvironment();
-    expect(result.runtime).toMatch(/^(node|bun|deno)@/);
+    expect(result.runtime).toMatch(/^(node|bun|deno)@.+/);
   });
 
   test('prefactor_sdk includes the core package', () => {

--- a/packages/core/tests/runtime-environment.test.ts
+++ b/packages/core/tests/runtime-environment.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { buildRuntimeEnvironment } from '../src/runtime-environment.js';
+import { PACKAGE_NAME, PACKAGE_VERSION } from '../src/version.js';
+
+describe('buildRuntimeEnvironment', () => {
+  test('returns all four keys', () => {
+    const result = buildRuntimeEnvironment();
+    expect(Object.keys(result).sort()).toEqual(['agent_sdk', 'os', 'prefactor_sdk', 'runtime']);
+  });
+
+  test('os matches process.platform', () => {
+    const result = buildRuntimeEnvironment();
+    const expected = process.platform === 'win32' ? 'windows' : process.platform;
+    expect(result.os).toBe(expected);
+  });
+
+  test('runtime identifies the JavaScript runtime', () => {
+    const result = buildRuntimeEnvironment();
+    expect(result.runtime).toMatch(/^(node|bun|deno)@/);
+  });
+
+  test('prefactor_sdk includes the core package', () => {
+    const result = buildRuntimeEnvironment();
+    expect(result.prefactor_sdk).toEqual([`${PACKAGE_NAME}@${PACKAGE_VERSION}`]);
+  });
+
+  test('agent_sdk is empty without a header', () => {
+    const result = buildRuntimeEnvironment();
+    expect(result.agent_sdk).toEqual([]);
+  });
+
+  test('agent_sdk is empty with an undefined header', () => {
+    const result = buildRuntimeEnvironment(undefined);
+    expect(result.agent_sdk).toEqual([]);
+  });
+
+  test('agent_sdk parses a single upstream entry', () => {
+    const result = buildRuntimeEnvironment('@prefactor/langchain@2.0.0');
+    expect(result.agent_sdk).toEqual(['@prefactor/langchain@2.0.0']);
+  });
+
+  test('agent_sdk parses multiple upstream entries', () => {
+    const result = buildRuntimeEnvironment('@prefactor/langchain@2.0.0 my-framework@1.0.0');
+    expect(result.agent_sdk).toEqual(['@prefactor/langchain@2.0.0', 'my-framework@1.0.0']);
+  });
+
+  test('agent_sdk strips the core self-entry', () => {
+    const result = buildRuntimeEnvironment(`${PACKAGE_NAME}@${PACKAGE_VERSION}`);
+    expect(result.agent_sdk).toEqual([]);
+  });
+
+  test('agent_sdk strips the core self-entry from a chained header', () => {
+    const result = buildRuntimeEnvironment(
+      `@prefactor/langchain@2.0.0 ${PACKAGE_NAME}@${PACKAGE_VERSION}`
+    );
+    expect(result.agent_sdk).toEqual(['@prefactor/langchain@2.0.0']);
+  });
+
+  test('agent_sdk handles surrounding whitespace', () => {
+    const result = buildRuntimeEnvironment('  @prefactor/langchain@2.0.0   ');
+    expect(result.agent_sdk).toEqual(['@prefactor/langchain@2.0.0']);
+  });
+});

--- a/packages/core/tests/shared/sdk-header.ts
+++ b/packages/core/tests/shared/sdk-header.ts
@@ -1,4 +1,5 @@
 import { expect } from 'bun:test';
+import { PACKAGE_NAME, PACKAGE_VERSION } from '../../src/version.js';
 
 type FetchCall = {
   url: string;
@@ -82,6 +83,19 @@ export function expectSdkHeaderHeaders(headers: Headers, sdkHeaderEntry: string)
   expect(headers.get('X-Prefactor-SDK')).toContain('prefactor/core@');
 }
 
-export function expectRuntimeMetadataOmitted(payload: Record<string, unknown>): void {
-  expect(payload.runtime_environment).toBeUndefined();
+export function expectRuntimeEnvironment(
+  payload: Record<string, unknown>,
+  expectedAgentSdk: string[] = []
+): void {
+  const agentVersion = payload.agent_version as Record<string, unknown> | undefined;
+  expect(agentVersion).toBeDefined();
+
+  const runtimeEnvironment = agentVersion?.runtime_environment as
+    | Record<string, unknown>
+    | undefined;
+  expect(runtimeEnvironment).toBeDefined();
+  expect(runtimeEnvironment?.agent_sdk).toEqual(expectedAgentSdk);
+  expect(runtimeEnvironment?.prefactor_sdk).toEqual([`${PACKAGE_NAME}@${PACKAGE_VERSION}`]);
+  expect(typeof runtimeEnvironment?.os).toBe('string');
+  expect(typeof runtimeEnvironment?.runtime).toBe('string');
 }

--- a/packages/core/tests/shared/sdk-header.ts
+++ b/packages/core/tests/shared/sdk-header.ts
@@ -97,5 +97,5 @@ export function expectRuntimeEnvironment(
   expect(runtimeEnvironment?.agent_sdk).toEqual(expectedAgentSdk);
   expect(runtimeEnvironment?.prefactor_sdk).toEqual([`${PACKAGE_NAME}@${PACKAGE_VERSION}`]);
   expect(typeof runtimeEnvironment?.os).toBe('string');
-  expect(typeof runtimeEnvironment?.runtime).toBe('string');
+  expect(runtimeEnvironment?.runtime).toMatch(/^(node|bun|deno)@.+/);
 }

--- a/packages/core/tests/transport/http-failure-modes.test.ts
+++ b/packages/core/tests/transport/http-failure-modes.test.ts
@@ -731,13 +731,13 @@ describe('HttpTransport failure modes', () => {
 
     expect(registerBodies).toHaveLength(2);
     expect(registerBodies[0]?.agent_schema_version).toEqual({ type: 'object' });
-    expect(registerBodies[0]?.agent_version).toEqual({
+    expect(registerBodies[0]?.agent_version).toMatchObject({
       external_identifier: 'v1.0.0',
       name: 'Agent',
       description: '',
     });
     expect(registerBodies[1]?.agent_schema_version).toEqual(updatedSchema);
-    expect(registerBodies[1]?.agent_version).toEqual({
+    expect(registerBodies[1]?.agent_version).toMatchObject({
       external_identifier: 'v1.1.0',
       name: 'Agent',
       description: '',

--- a/packages/core/tests/transport/http.test.ts
+++ b/packages/core/tests/transport/http.test.ts
@@ -55,8 +55,44 @@ describe('HttpTransport', () => {
     const registerHeaders = new Headers(fetchCalls[0]?.options?.headers);
     expect(registerPayload.agent_id).toBe('agent-123');
     expect(registerPayload.agent_schema_version).toEqual({ type: 'object' });
-    expect(registerPayload.runtime_environment).toBeUndefined();
+    const agentVersion = registerPayload.agent_version as Record<string, unknown>;
+    expect(agentVersion.runtime_environment).toBeDefined();
     expect(registerHeaders.get('X-Prefactor-SDK')).toBe(DEFAULT_SDK_HEADER);
+  });
+
+  test('includes runtime_environment in agent_version on register', async () => {
+    const fetchCalls: Array<{ url: string; options?: RequestInit }> = [];
+    globalThis.fetch = (async (url, options) => {
+      fetchCalls.push({ url: String(url), options });
+      if (String(url).endsWith('/agent_instance/register')) {
+        return new Response(JSON.stringify({ details: { id: 'agent-instance-1' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const transport = new HttpTransport(createConfig(), {
+      sdkHeaderEntry: '@prefactor/langchain@2.0.0',
+    });
+    transport.startAgentInstance();
+    await transport.close();
+
+    const registerPayload = JSON.parse(fetchCalls[0]?.options?.body as string) as Record<
+      string,
+      unknown
+    >;
+    const agentVersion = registerPayload.agent_version as Record<string, unknown>;
+    const runtimeEnvironment = agentVersion.runtime_environment as Record<string, unknown>;
+    expect(runtimeEnvironment.agent_sdk).toEqual(['@prefactor/langchain@2.0.0']);
+    expect(runtimeEnvironment.prefactor_sdk).toEqual([`${PACKAGE_NAME}@${PACKAGE_VERSION}`]);
+    expect(typeof runtimeEnvironment.os).toBe('string');
+    expect(typeof runtimeEnvironment.runtime).toBe('string');
   });
 
   test('buffers span finish until span emit maps backend id', async () => {
@@ -325,7 +361,7 @@ describe('HttpTransport', () => {
       unknown
     >;
     expect(registerPayload.agent_schema_version).toEqual(updatedSchema);
-    expect(registerPayload.agent_version).toEqual({
+    expect(registerPayload.agent_version).toMatchObject({
       external_identifier: 'v1.1.0',
       name: 'Agent',
       description: '',

--- a/packages/langchain/tests/init.test.ts
+++ b/packages/langchain/tests/init.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
 import { AgentInstanceManager, getClient, init as initCore, Tracer } from '@prefactor/core';
 import {
   createSdkHeaderFetchRecorder,
-  expectRuntimeMetadataOmitted,
+  expectRuntimeEnvironment,
   expectSdkHeaderHeaders,
 } from '../../core/tests/shared/sdk-header.js';
 import { init, shutdown, withSpan } from '../src/init.js';
@@ -221,7 +221,7 @@ describe('langchain init schema registration', () => {
     }
   });
 
-  test('sends adapter sdk header for package init and omits runtime metadata body fields', async () => {
+  test('sends adapter sdk header and runtime environment for package init', async () => {
     const recorder = createSdkHeaderFetchRecorder({ includeSpanResponses: true });
     globalThis.fetch = recorder.fetch;
 
@@ -237,7 +237,7 @@ describe('langchain init schema registration', () => {
     await shutdown();
 
     expectSdkHeaderHeaders(recorder.getRegisterHeaders(), LANGCHAIN_SDK_HEADER_ENTRY);
-    expectRuntimeMetadataOmitted(recorder.getRegisterPayload());
+    expectRuntimeEnvironment(recorder.getRegisterPayload(), [LANGCHAIN_SDK_HEADER_ENTRY]);
   });
 
   test('sends adapter sdk header for the core provider path', async () => {


### PR DESCRIPTION
Populate the optional runtime_environment field of agent_version automatically, matching the Python SDK (PRE-502). Reports prefactor_sdk, agent_sdk (from the SDK header chain), runtime (node/bun/deno + version), and os (host platform) with no user configuration required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent registration now automatically includes runtime environment details, including installed SDKs, operating system, and JavaScript runtime and version.
  * Runtime information is detected across Node.js, Bun, and Deno environments without additional configuration.
  * Added public APIs for accessing runtime environment information programmatically.

* **Bug Fixes**
  * Registration payload handling now supports additional runtime metadata while preserving compatibility with schema revisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->